### PR TITLE
chore: use safeArea from safe-area-context

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -3,4 +3,19 @@ module.exports = {
   extends: '@react-native-community',
   parser: '@typescript-eslint/parser',
   plugins: ['@typescript-eslint'],
+  rules: {
+    'no-restricted-imports': [
+      2,
+      {
+        paths: [
+          {
+            name: 'react-native',
+            importNames: ['SafeAreaView'],
+            message:
+              'Using SafeAreaView from RN may result in buggy appearance, use react-native-safe-area-context instead.',
+          },
+        ],
+      },
+    ],
+  },
 };

--- a/package.json
+++ b/package.json
@@ -126,6 +126,6 @@
   },
   "lint-staged": {
     "*.+(ts|tsx)": "eslint --fix",
-    "*.+(ts|tsx|json)": "prettier --write"
+    "*.+(ts|tsx|json|js)": "prettier --write"
   }
 }

--- a/src/layout/ScreenNavigation.tsx
+++ b/src/layout/ScreenNavigation.tsx
@@ -6,7 +6,8 @@ import {
   IconProps,
   useTheme,
 } from '@ui-kitten/components';
-import {StyleSheet, SafeAreaView, View} from 'react-native';
+import {StyleSheet, View} from 'react-native';
+import {SafeAreaView} from 'react-native-safe-area-context';
 
 const MenuIcon = (props: IconProps) => (
   <Icon {...props} name="menu-2-outline" />
@@ -36,6 +37,7 @@ export default function ScreenNavigation({
 
   return (
     <SafeAreaView
+      edges={['top', 'right', 'left']}
       style={{backgroundColor: themeVars['background-basic-color-1']}}>
       <View style={styles.container}>
         <TopNavigation

--- a/src/presentational/SafeView.tsx
+++ b/src/presentational/SafeView.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
-import {SafeAreaView, StyleSheet} from 'react-native';
+import {StyleSheet} from 'react-native';
+import {SafeAreaView} from 'react-native-safe-area-context';
+
 import {Layout} from '@ui-kitten/components';
 
 export default function SafeView({children}: {children: React.ReactNode}) {


### PR DESCRIPTION
hi there! I was just passing by and looked at some of the files and noticed the SafeArea from RN was being used. This can sometimes lead to visual bugs (see https://reactnavigation.org/docs/handling-safe-area/) so I replaces that usage with https://github.com/th3rdwave/react-native-safe-area-context

I replaced the SafeArea from RN and added a new eslint rule that forbids that import

Note that I did not go to all the screens to see if everything looks as expected.

hope this helps, thanks :)