### PR TITLE
Feature/56 utf8 decode problem

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 import './shim';
 import 'proxy-polyfill'; // added for android hermes engine, double check when upgrade RN to 0.64
 import 'react-native-gesture-handler';
+import 'fast-text-encoding';
 import React from 'react';
 import {AppRegistry} from 'react-native';
 import App from './src/App';

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "@ui-kitten/eva-icons": "^5.0.0",
     "console-browserify": "^1.2.0",
     "events": "^1.1.1",
+    "fast-text-encoding": "^1.0.3",
     "lodash": "^4.17.20",
     "process": "^0.11.10",
     "proxy-polyfill": "^0.3.2",

--- a/src/layout/AccountTeaser.tsx
+++ b/src/layout/AccountTeaser.tsx
@@ -26,7 +26,7 @@ import {ChainApiContext} from 'context/ChainApiContext';
 import useAccountDetail from 'src/hook/useAccountDetail';
 import {useNavigation} from '@react-navigation/native';
 
-const {width, height} = Dimensions.get('window');
+const {width} = Dimensions.get('window');
 
 type PropTypes = {
   level: '1' | '2';
@@ -74,7 +74,9 @@ function AccountTeaser(props: PropTypes) {
     <Layout
       level={props.level}
       style={[globalStyles.paddedContainer, styles.container]}>
-      <TouchableOpacity onPress={() => handleIconPressed(account?.address)}>
+      <TouchableOpacity
+        style={styles.identIconContainer}
+        onPress={() => handleIconPressed(account?.address)}>
         <Identicon value={address} size={60} />
       </TouchableOpacity>
       {display ? (
@@ -130,7 +132,6 @@ const styles = StyleSheet.create({
   container: {
     justifyContent: 'space-around',
     alignItems: 'center',
-    height: height * 0.2,
   },
   addressContainer: {
     flexDirection: 'row',
@@ -153,6 +154,9 @@ const styles = StyleSheet.create({
   },
   qrAddressText: {
     padding: standardPadding,
+  },
+  identIconContainer: {
+    marginBottom: 10,
   },
 });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4183,6 +4183,11 @@ fast-levenshtein@^2.0.6, fast-levenshtein@~2.0.6:
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
   integrity sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=
 
+fast-text-encoding@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/fast-text-encoding/-/fast-text-encoding-1.0.3.tgz#ec02ac8e01ab8a319af182dae2681213cfe9ce53"
+  integrity sha512-dtm4QZH9nZtcDt8qJiOH9fcQd1NAgi+K1O2DbE6GG1PPCK/BWfOH3idCTRQ4ImXRUOyopDEgDEnVEE7Y/2Wrig==
+
 fb-watchman@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/fb-watchman/-/fb-watchman-2.0.1.tgz#fc84fb39d2709cf3ff6d743706157bb5708a8a85"


### PR DESCRIPTION
Apparently, in contrast with javascript engines running on browsers, rn javascript engine does not have a global TextDecoder object. Therefore, u8aToString from the package @polkadot/util fails to decode emojis as it is only good for ASCII chars

https://github.com/polkadot-js/common/blob/ec286a57d12b9ba6aab67eed4c258128bed88bf3/packages/x-textdecoder/src/fallback.ts#L4

fast-text-encoding package is adding the missing TextDecoder with the ability to decode full utf-8 back to the global context