### PR TITLE
Adding useApiTx hook for starting transactions

### DIFF
--- a/src/api/hooks/useApiTx.ts
+++ b/src/api/hooks/useApiTx.ts
@@ -1,6 +1,7 @@
 import {useContext} from 'react';
 import {useApi} from 'context/ChainApiContext';
 import {TxContext, StartConfig} from 'context/TxContext';
+import {ApiPromise} from '@polkadot/api';
 
 type TxConfig = Omit<StartConfig, 'api'>;
 
@@ -8,10 +9,13 @@ export function useApiTx() {
   const {start} = useContext(TxContext);
   const {api} = useApi();
 
-  return (config: TxConfig) => {
+  return (config: TxConfig | ((apiPromise: ApiPromise) => TxConfig)) => {
     if (!api) {
       return Promise.reject(new Error('API is not defined'));
     }
-    return start({api, ...config});
+
+    const startConfig = typeof config === 'function' ? config(api) : config;
+
+    return start({api, ...startConfig});
   };
 }

--- a/src/api/hooks/useApiTx.ts
+++ b/src/api/hooks/useApiTx.ts
@@ -1,0 +1,17 @@
+import {useContext} from 'react';
+import {useApi} from 'context/ChainApiContext';
+import {TxContext, StartConfig} from 'context/TxContext';
+
+type TxConfig = Omit<StartConfig, 'api'>;
+
+export function useApiTx() {
+  const {start} = useContext(TxContext);
+  const {api} = useApi();
+
+  return (config: TxConfig) => {
+    if (!api) {
+      return Promise.reject(new Error('API is not defined'));
+    }
+    return start({api, ...config});
+  };
+}

--- a/src/context/TxContext/index.tsx
+++ b/src/context/TxContext/index.tsx
@@ -10,7 +10,7 @@ import ErrorDialog from 'presentational/ErrorDialog';
 import LoadingView from 'presentational/LoadingView';
 import SuccessDialog from 'presentational/SuccessDialog';
 import TxPayloadQr from 'presentational/TxPayloadQr';
-import React, {createContext, useCallback, useContext, useMemo, useReducer, useRef} from 'react';
+import React, {createContext, useCallback, useMemo, useReducer, useRef} from 'react';
 import {Dimensions, StyleSheet} from 'react-native';
 import {Modalize} from 'react-native-modalize';
 import QRCodeScanner from 'react-native-qrcode-scanner';
@@ -30,8 +30,6 @@ type TxContextValueType = {
 export const TxContext = createContext<TxContextValueType>({
   start: () => Promise.resolve(),
 });
-
-export const useTX = () => useContext(TxContext);
 
 const AlertIcon = (props: IconProps) => <Icon fill="#ccc" {...props} name="alert-triangle-outline" />;
 

--- a/src/context/TxContext/index.tsx
+++ b/src/context/TxContext/index.tsx
@@ -35,7 +35,7 @@ export const useTX = () => useContext(TxContext);
 
 const AlertIcon = (props: IconProps) => <Icon fill="#ccc" {...props} name="alert-triangle-outline" />;
 
-type StartConfig = {
+export type StartConfig = {
   api: ApiPromise;
   address: string;
   txMethod: string;

--- a/src/presentational/SubmitProposalButton.tsx
+++ b/src/presentational/SubmitProposalButton.tsx
@@ -1,10 +1,10 @@
-import {Button, Card, Icon, Input, Modal, Text} from '@ui-kitten/components';
-import {useApi} from 'context/ChainApiContext';
-import {useTX} from 'context/TxContext';
-import Padder from 'presentational/Padder';
-import {SelectAccount} from 'presentational/SelectAccount';
 import React from 'react';
 import {StyleSheet, View} from 'react-native';
+import {Button, Card, Icon, Input, Modal, Text} from '@ui-kitten/components';
+import {useApi} from 'context/ChainApiContext';
+import Padder from 'presentational/Padder';
+import {SelectAccount} from 'presentational/SelectAccount';
+import {useApiTx} from 'src/api/hooks/useApiTx';
 import {useFormatBalance} from 'src/api/hooks/useFormatBalance';
 import {getBalanceFromString} from 'src/api/utils/balance';
 import globalStyles, {standardPadding} from 'src/styles';
@@ -13,7 +13,7 @@ export function SubmitProposalButton() {
   const {api} = useApi();
   const [state, dispatch] = React.useReducer(reducer, initialState);
   const formatBalance = useFormatBalance();
-  const {start} = useTX();
+  const startTx = useApiTx();
 
   return (
     <>
@@ -78,9 +78,7 @@ export function SubmitProposalButton() {
               onPress={() => {
                 if (api && state.balance && state.account) {
                   const balance = getBalanceFromString(api, state.balance);
-
-                  start({
-                    api,
+                  startTx({
                     address: state.account,
                     txMethod: 'democracy.propose',
                     params: [state.preimageHash, balance],

--- a/src/screen/Council/MotionsScreen.tsx
+++ b/src/screen/Council/MotionsScreen.tsx
@@ -1,12 +1,11 @@
 import React, {useContext} from 'react';
+import {FlatList, StyleSheet, View} from 'react-native';
 import {useQueryClient} from 'react-query';
 import {Button, Card, Divider, ListItem, Text} from '@ui-kitten/components';
-import {FlatList, StyleSheet, View} from 'react-native';
 import {formatNumber} from '@polkadot/util';
 import type {DeriveCollectiveProposal} from '@polkadot/api-derive/types';
 
 import {ChainApiContext} from 'context/ChainApiContext';
-import {TxContext} from 'context/TxContext';
 import {EmptyView} from 'presentational/EmptyView';
 import Padder from 'presentational/Padder';
 import {useAccounts} from 'context/AccountsContext';
@@ -20,6 +19,7 @@ import {NavigationProp, useNavigation} from '@react-navigation/native';
 import {motionDetailScreen} from 'src/navigation/routeKeys';
 import {DashboardStackParamList} from 'src/navigation/navigation';
 import LoadingView from 'presentational/LoadingView';
+import {useApiTx} from 'src/api/hooks/useApiTx';
 
 export function MotionsScreen() {
   const {data, refetch, isLoading, isFetching} = useCouncilMotions();
@@ -51,7 +51,7 @@ const styles = StyleSheet.create({flatList: {padding: standardPadding * 2}});
 function Motion({item}: {item: DeriveCollectiveProposal}) {
   const navigation = useNavigation<NavigationProp<DashboardStackParamList>>();
   const {api} = useContext(ChainApiContext);
-  const {start} = useContext(TxContext);
+  const startTx = useApiTx();
   const {accounts} = useAccounts();
   const account = accounts?.[0];
 
@@ -63,11 +63,10 @@ function Motion({item}: {item: DeriveCollectiveProposal}) {
   const queryClient = useQueryClient();
 
   const onPressClose = () => {
-    if (api && account) {
-      start({
-        api,
+    if (account) {
+      startTx({
         address: account.address,
-        params: api.tx.council.close?.meta.args.length === 4 ? [hash, votes?.index, 0, 0] : [hash, votes?.index],
+        params: api?.tx.council.close?.meta.args.length === 4 ? [hash, votes?.index, 0, 0] : [hash, votes?.index],
         txMethod: 'council.close',
       })
         .then(() => {
@@ -78,9 +77,8 @@ function Motion({item}: {item: DeriveCollectiveProposal}) {
   };
 
   const onPressNay = () => {
-    if (api && account) {
-      start({
-        api,
+    if (account) {
+      startTx({
         address: account.address,
         params: [hash, votes?.index, false],
         txMethod: 'council.vote',
@@ -91,9 +89,8 @@ function Motion({item}: {item: DeriveCollectiveProposal}) {
   };
 
   const onPressAye = () => {
-    if (api && account) {
-      start({
-        api,
+    if (account) {
+      startTx({
         address: account.address,
         params: [hash, votes?.index, true],
         txMethod: 'council.vote',

--- a/src/screen/DemocracyProposalScreen.tsx
+++ b/src/screen/DemocracyProposalScreen.tsx
@@ -1,7 +1,9 @@
+import React, {useReducer, useState} from 'react';
+import {StyleSheet, TouchableOpacity, View} from 'react-native';
+import {ScrollView} from 'react-native-gesture-handler';
 import {RouteProp} from '@react-navigation/native';
 import {Button, Card, Icon, Layout, Modal, Text} from '@ui-kitten/components';
 import {useApi} from 'context/ChainApiContext';
-import {useTX} from 'context/TxContext';
 import AddressInlineTeaser from 'layout/AddressInlineTeaser';
 import {EmptyView} from 'presentational/EmptyView';
 import LoadingView from 'presentational/LoadingView';
@@ -9,9 +11,7 @@ import Padder from 'presentational/Padder';
 import {ProposalInfo} from 'presentational/ProposalInfo';
 import SafeView, {noTopEdges} from 'presentational/SafeView';
 import {SelectAccount} from 'presentational/SelectAccount';
-import React, {useReducer, useState} from 'react';
-import {StyleSheet, TouchableOpacity, View} from 'react-native';
-import {ScrollView} from 'react-native-gesture-handler';
+import {useApiTx} from 'src/api/hooks/useApiTx';
 import {useDemocracy} from 'src/api/hooks/useDemocracy';
 import {useFormatBalance} from 'src/api/hooks/useFormatBalance';
 import {DashboardStackParamList} from 'src/navigation/navigation';
@@ -19,7 +19,7 @@ import {referendumScreen} from 'src/navigation/routeKeys';
 import globalStyles, {standardPadding} from 'src/styles';
 
 export function DemocracyProposalScreen({route}: {route: RouteProp<DashboardStackParamList, typeof referendumScreen>}) {
-  const {start} = useTX();
+  const startTx = useApiTx();
   const {api} = useApi();
 
   const [secondsOpen, setSecondsOpen] = useState(false);
@@ -172,13 +172,12 @@ export function DemocracyProposalScreen({route}: {route: RouteProp<DashboardStac
               <Button
                 disabled={!state.account}
                 onPress={() => {
-                  if (api && state.account) {
-                    start({
-                      api,
+                  if (state.account) {
+                    startTx({
                       address: state.account,
                       txMethod: 'democracy.second',
                       params:
-                        api.tx.democracy.second.meta.args.length === 2
+                        api?.tx.democracy.second.meta.args.length === 2
                           ? [activeProposal.index, activeProposal.seconds.length]
                           : [activeProposal.index],
                     });

--- a/src/screen/ReferendumScreen.tsx
+++ b/src/screen/ReferendumScreen.tsx
@@ -1,3 +1,5 @@
+import React, {useReducer} from 'react';
+import {StyleSheet, View} from 'react-native';
 import {BN, BN_ONE} from '@polkadot/util';
 import {RouteProp} from '@react-navigation/native';
 import {
@@ -14,13 +16,11 @@ import {
   Text,
 } from '@ui-kitten/components';
 import {useApi} from 'context/ChainApiContext';
-import {useTX} from 'context/TxContext';
 import Padder from 'presentational/Padder';
 import {ProgressBar} from 'presentational/ProgressBar';
 import SafeView, {noTopEdges} from 'presentational/SafeView';
 import {SelectAccount} from 'presentational/SelectAccount';
-import React, {useReducer} from 'react';
-import {StyleSheet, View} from 'react-native';
+import {useApiTx} from 'src/api/hooks/useApiTx';
 import {useBestNumber} from 'src/api/hooks/useBestNumber';
 import {useBlockTime} from 'src/api/hooks/useBlockTime';
 import {useConvictions} from 'src/api/hooks/useConvictions';
@@ -33,7 +33,7 @@ import {formatCallMeta} from 'src/packages/call_inspector/CallInspector';
 import globalStyles, {standardPadding} from 'src/styles';
 
 export function ReferendumScreen({route}: {route: RouteProp<DashboardStackParamList, typeof referendumScreen>}) {
-  const {start} = useTX();
+  const startTx = useApiTx();
   const {api} = useApi();
 
   const [state, dispatch] = useReducer(reducer, initialState);
@@ -212,9 +212,7 @@ export function ReferendumScreen({route}: {route: RouteProp<DashboardStackParamL
                 onPress={() => {
                   if (api && state.account && selectedConviction) {
                     const balance = getBalanceFromString(api, state.voteValue);
-
-                    start({
-                      api,
+                    startTx({
                       address: state.account,
                       txMethod: 'democracy.vote',
                       params: [

--- a/src/screen/SubmitTipScreen.tsx
+++ b/src/screen/SubmitTipScreen.tsx
@@ -1,24 +1,21 @@
+import React, {useReducer} from 'react';
+import {StyleSheet, View} from 'react-native';
+import {useQueryClient} from 'react-query';
 import {NavigationProp} from '@react-navigation/native';
 import {Button, Card, Input, Text} from '@ui-kitten/components';
-import {ChainApiContext} from 'context/ChainApiContext';
-import {TxContext} from 'context/TxContext';
 import Padder from 'presentational/Padder';
 import SafeView, {noTopEdges} from 'presentational/SafeView';
 import {SelectAccount} from 'presentational/SelectAccount';
-import * as React from 'react';
-import {useContext, useReducer} from 'react';
-import {StyleSheet, View} from 'react-native';
-import {useQueryClient} from 'react-query';
 import {DashboardStackParamList} from 'src/navigation/navigation';
 import globalStyles, {standardPadding} from 'src/styles';
+import {useApiTx} from 'src/api/hooks/useApiTx';
 
 export function SubmitTipScreen({navigation}: {navigation: NavigationProp<DashboardStackParamList>}) {
   const [state, dispatch] = useReducer(reducer, initialState);
-  const {start} = useContext(TxContext);
-  const {api} = useContext(ChainApiContext);
+  const startTx = useApiTx();
   const queryClient = useQueryClient();
 
-  const valid = api && state.account && state.beneficiary && state.reason && state.reason.length > 4;
+  const valid = state.account && state.beneficiary && state.reason && state.reason.length > 4;
 
   return (
     <SafeView edges={noTopEdges}>
@@ -56,9 +53,8 @@ export function SubmitTipScreen({navigation}: {navigation: NavigationProp<Dashbo
         <Button
           disabled={!valid}
           onPress={() => {
-            if (api && state.account) {
-              start({
-                api,
+            if (state.account) {
+              startTx({
                 address: state.account,
                 txMethod: 'tips.reportAwesome',
                 params: [state.reason, state.beneficiary],


### PR DESCRIPTION
Adding new hook to be able to start transactions without having to always get the api and start from the respective contexts.

I thought we could clean a little more code but in several places we still need the api. However, the logic is still improved a little, later we can revisit the logic when we integrate with other methods to sign the transactions.

Fixes #307 