### PR TITLE
Refactoring Tx result

### DIFF
--- a/src/context/TxContext/index.tsx
+++ b/src/context/TxContext/index.tsx
@@ -51,7 +51,7 @@ function TxContextProvider({children}: PropTypes): React.ReactElement {
     if (!apiPromise?.isConnected && state.step === 'submitting') {
       dispatch({
         type: 'WARNING',
-        payload: 'The transaction was sent but you got disconnected from the chain. Please verify later',
+        payload: 'The transaction was sent but you got disconnected from the chain. Please verify later.',
       });
     }
   }, [apiPromise?.isConnected, state.step]);

--- a/src/context/TxContext/index.tsx
+++ b/src/context/TxContext/index.tsx
@@ -341,7 +341,6 @@ type Action =
   | {type: 'NEXT_STEP'}
   | {type: 'ERROR'; payload: string}
   | {type: 'WARNING'; payload: string}
-  | {type: 'WARNING'; payload: string}
   | {
       type: 'PREVIEW';
       payload: {

--- a/src/presentational/WarningDialog.tsx
+++ b/src/presentational/WarningDialog.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import {StyleSheet} from 'react-native';
+import {Layout, Text, Icon} from '@ui-kitten/components';
+import globalStyles, {standardPadding, monofontFamily} from 'src/styles';
+
+type PropTypes = {
+  text: string;
+  msg: string;
+};
+
+function WarningDialog(props: PropTypes) {
+  const {text, msg} = props;
+
+  return (
+    <Layout style={globalStyles.centeredContainer}>
+      <Layout style={styles.textContainer}>
+        <Icon style={styles.icon} fill={'#ffcc00'} name="alert-circle-outline" />
+        <Text style={[styles.text, styles.withIcon]}>{text}</Text>
+      </Layout>
+      <Text>{msg}</Text>
+    </Layout>
+  );
+}
+
+const styles = StyleSheet.create({
+  textContainer: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  withIcon: {
+    paddingLeft: standardPadding,
+  },
+  icon: {width: 20, height: 20},
+  text: {
+    fontWeight: 'bold',
+    fontFamily: monofontFamily,
+    padding: standardPadding * 4,
+  },
+});
+export default WarningDialog;


### PR DESCRIPTION
Getting the transaction status and errors directly from the transaction's result instead of looping over the events. In addition a warning step was added for the rare cases where a transaction was sent and the api got disconnected to give feedback to the  users. It will display a dialog similar to the error dialogs as shown down below

![Screenshot_20210902-110330_Litentry](https://user-images.githubusercontent.com/8374946/131818128-1f9b35a7-5706-4bd8-b7bc-5c5464b4b447.jpg)
