### PR TITLE
Add internal accounts in context

### DIFF
--- a/src/context/AccountsContext.tsx
+++ b/src/context/AccountsContext.tsx
@@ -8,6 +8,7 @@ export type Account = {
   address: string;
   name: string;
   isFavorite: boolean;
+  isInternal: boolean;
 };
 
 type State = {

--- a/src/context/ChainApiContext.tsx
+++ b/src/context/ChainApiContext.tsx
@@ -4,6 +4,7 @@ import {createLogger} from 'src/utils';
 import {NetworkContext} from './NetworkContext';
 import {keyring} from '@polkadot/ui-keyring';
 import {keyringStore} from 'src/service/KeyringStore';
+import {NetworkType} from 'src/types';
 
 const initialState: ChainApiContext = {
   status: 'unknown',
@@ -11,6 +12,8 @@ const initialState: ChainApiContext = {
   api: undefined,
   wsConnectionIndex: 0,
 };
+
+keyring.loadAll({store: keyringStore, type: 'sr25519'});
 
 export const ChainApiContext = createContext<ChainApiContext>(initialState);
 
@@ -43,11 +46,7 @@ export function ChainApiContextProvider({children}: {children: React.ReactNode})
 
     function handleReady() {
       logger.debug('ChainApiContext: Api ready at', wsAddress);
-      keyring.loadAll({
-        ss58Format: currentNetwork.ss58Format,
-        store: keyringStore,
-        type: 'sr25519',
-      });
+      keyring.setSS58Format(currentNetwork.ss58Format);
       dispatch({type: 'ON_READY', payload: apiPromise});
     }
 

--- a/src/context/ChainApiContext.tsx
+++ b/src/context/ChainApiContext.tsx
@@ -46,6 +46,7 @@ export function ChainApiContextProvider({children}: {children: React.ReactNode})
       keyring.loadAll({
         ss58Format: currentNetwork.ss58Format,
         store: keyringStore,
+        type: 'sr25519',
       });
       dispatch({type: 'ON_READY', payload: apiPromise});
     }

--- a/src/screen/AccountsScreen.tsx
+++ b/src/screen/AccountsScreen.tsx
@@ -1,5 +1,4 @@
 import Identicon from '@polkadot/reactnative-identicon';
-import {keyring} from '@polkadot/ui-keyring';
 import {NavigationProp} from '@react-navigation/native';
 import {Button, Divider, Icon, ListItem, MenuItem, OverflowMenu, Text, useTheme} from '@ui-kitten/components';
 import {Account, useAccounts} from 'context/AccountsContext';
@@ -35,8 +34,6 @@ export function AccountsScreen({navigation}: {navigation: NavigationProp<Complet
   const sortByFunction = sortBy === 'name' ? sortByDisplayName : sortByIsFavorite;
   const [sortMenuVisible, setSortMenuVisible] = React.useState(false);
 
-  const internalAccounts = keyring.getAccounts();
-
   return (
     <SafeView edges={noTopEdges}>
       {isLoading ? (
@@ -50,6 +47,7 @@ export function AccountsScreen({navigation}: {navigation: NavigationProp<Complet
           keyExtractor={(item) => item.account.address}
           renderItem={({item}) => (
             <AccountItem
+              isInternal={item.account.isInternal}
               identity={item.identity}
               isFavorite={item.account.isFavorite}
               toggleFavorite={() => toggleFavorite(item.account.address)}
@@ -130,14 +128,6 @@ export function AccountsScreen({navigation}: {navigation: NavigationProp<Complet
                 accessoryLeft={(p) => <Icon {...p} name="download-outline" />}>
                 Import account
               </Button>
-              <View>
-                <Text>{internalAccounts.length} internal accounts</Text>
-                {internalAccounts.map((account) => (
-                  <Text key={account.address} category="c1">
-                    {account.address}
-                  </Text>
-                ))}
-              </View>
             </View>
           )}
         />
@@ -181,6 +171,7 @@ function sortByIsFavorite(a: CombinedData, b: CombinedData) {
 }
 
 function AccountItem({
+  isInternal,
   identity,
   isFavorite,
   toggleFavorite,
@@ -188,10 +179,13 @@ function AccountItem({
 }: {
   identity: IdentityInfo;
   isFavorite: boolean;
+  isInternal: boolean;
   toggleFavorite: () => void;
   onPress: () => void;
 }) {
   const theme = useTheme();
+
+  console.log(isInternal);
 
   return (
     <ListItem
@@ -201,6 +195,7 @@ function AccountItem({
           <Identicon value={String(identity.accountId)} size={25} />
         </View>
       )}
+      description={`${isInternal ? 'Internal' : ''}`}
       title={(p) => (
         <View {...p}>
           <AccountInfoInlineTeaser identity={identity} />

--- a/src/screen/AddAccountScreen/AddAccountScreen.tsx
+++ b/src/screen/AddAccountScreen/AddAccountScreen.tsx
@@ -41,7 +41,7 @@ export function AddAccountScreen({navigation}: {navigation: NavigationProp<AppSt
     }
 
     if (state.step === 'preview') {
-      addAccount(currentNetwork.key, {address: state.address, name: '', isFavorite: false});
+      addAccount(currentNetwork.key, {address: state.address, name: '', isFavorite: false, isInternal: false});
       dispatch({type: 'SET_STEP', payload: 'success'});
       return;
     }

--- a/src/screen/CreateAccountScreen.tsx
+++ b/src/screen/CreateAccountScreen.tsx
@@ -15,9 +15,15 @@ import {keyring} from '@polkadot/ui-keyring';
 import {NavigationProp} from '@react-navigation/native';
 import {AccountsStackParamList} from 'src/navigation/navigation';
 import {accountsScreen} from 'src/navigation/routeKeys';
+import {useAccounts} from 'context/AccountsContext';
+import {NetworkContext} from 'context/NetworkContext';
 
 export function CreateAccountScreen({navigation}: {navigation: NavigationProp<AccountsStackParamList>}) {
   const theme = useTheme();
+
+  const {currentNetwork} = React.useContext(NetworkContext);
+  const {addAccount} = useAccounts();
+
   const [mnemonic] = React.useState(mnemonicGenerate());
   const [account, setAccount] = React.useState<{
     title: string;
@@ -39,7 +45,13 @@ export function CreateAccountScreen({navigation}: {navigation: NavigationProp<Ac
   );
 
   const onSubmit = () => {
-    keyring.addUri(mnemonic, account.password, {name: account.title});
+    const {json: key} = keyring.addUri(mnemonic, account.password, {name: account.title});
+    addAccount(currentNetwork.key, {
+      address: key.address,
+      name: key.meta.name as string,
+      isFavorite: false,
+      isInternal: true,
+    });
     navigation.navigate(accountsScreen, {reload: true});
   };
 

--- a/src/screen/DevScreen.tsx
+++ b/src/screen/DevScreen.tsx
@@ -139,6 +139,7 @@ function DevScreen() {
                       name: 'Manu. set Acct',
                       address: '167rjWHghVwBJ52mz8sNkqr5bKu5vpchbc9CBoieBhVX714h',
                       isFavorite: false,
+                      isInternal: false,
                     });
                     Alert.alert('Done');
                   }}>

--- a/src/screen/ImportAccountWithJsonFileScreen.tsx
+++ b/src/screen/ImportAccountWithJsonFileScreen.tsx
@@ -13,9 +13,15 @@ import {keyring} from '@polkadot/ui-keyring';
 import {NavigationProp} from '@react-navigation/core';
 import {AccountsStackParamList} from 'src/navigation/navigation';
 import {accountsScreen} from 'src/navigation/routeKeys';
+import {NetworkContext} from 'context/NetworkContext';
+import {useAccounts} from 'context/AccountsContext';
 
 export function ImportAccountWithJsonFileScreen({navigation}: {navigation: NavigationProp<AccountsStackParamList>}) {
   const theme = useTheme();
+
+  const {currentNetwork} = React.useContext(NetworkContext);
+  const {addAccount} = useAccounts();
+
   const [jsonContent, setJsonContent] = React.useState<string>();
   const [error, setError] = React.useState<string | undefined>(undefined);
   const parsedJson = jsonContent ? tryParseJson(jsonContent) : undefined;
@@ -24,7 +30,14 @@ export function ImportAccountWithJsonFileScreen({navigation}: {navigation: Navig
 
   function restoreAccount() {
     if (parsedJson && password) {
-      keyring.restoreAccount(parsedJson, password);
+      const pair = keyring.restoreAccount(parsedJson, password);
+      const pairJson = pair.toJson(password);
+      addAccount(currentNetwork.key, {
+        address: pairJson.address,
+        name: pairJson.meta.name as string,
+        isFavorite: false,
+        isInternal: true,
+      });
       navigation.navigate(accountsScreen, {reload: true});
     }
   }


### PR DESCRIPTION
<img align=right width=250 src=https://user-images.githubusercontent.com/16683923/137283527-85cbd120-4382-4264-af6c-99c95931559f.png />

### Description
Add internal accounts (created from seed/imported) into the AccountContext.


## Converted to draft. Please don't review now. Things will change....