### PR TITLE
Feature-470 Show internal accounts

### DIFF
--- a/src/context/AccountsContext.tsx
+++ b/src/context/AccountsContext.tsx
@@ -48,7 +48,7 @@ function AccountsProvider({children}: {children: React.ReactNode}) {
         setAccounts(keyringAccounts);
       });
 
-      unsubscribe = subscription.unsubscribe;
+      unsubscribe = subscription.unsubscribe.bind(subscription);
     }
 
     return () => {

--- a/src/context/AccountsContext.tsx
+++ b/src/context/AccountsContext.tsx
@@ -8,6 +8,7 @@ export type Account = {
   address: string;
   name: string;
   isFavorite: boolean;
+  isInternal: boolean;
 };
 
 type State = {

--- a/src/context/AccountsContext.tsx
+++ b/src/context/AccountsContext.tsx
@@ -29,8 +29,8 @@ function AccountsProvider({children}: {children: React.ReactNode}) {
     if (api) {
       const subscription = keyring.accounts.subject.subscribe((accounts) => {
         const keyringAccounts = Object.values(accounts).reduce((map, {json}) => {
-          if (json.meta.network === currentNetwork.key) {
-            const pair = keyring.getPair(json.address);
+          const pair = tryGetPair(json.address);
+          if (json.meta.network === currentNetwork.key && pair) {
             map = {
               ...map,
               [pair.address]: {
@@ -57,6 +57,14 @@ function AccountsProvider({children}: {children: React.ReactNode}) {
   }, [currentNetwork, api]);
 
   return <AccountsContext.Provider value={accounts}>{children}</AccountsContext.Provider>;
+}
+
+function tryGetPair(address: string) {
+  try {
+    return keyring.getPair(address);
+  } catch (e) {
+    return undefined;
+  }
 }
 
 function useAccounts() {

--- a/src/context/ChainApiContext.tsx
+++ b/src/context/ChainApiContext.tsx
@@ -4,6 +4,7 @@ import {createLogger} from 'src/utils';
 import {NetworkContext} from './NetworkContext';
 import {keyring} from '@polkadot/ui-keyring';
 import {keyringStore} from 'src/service/KeyringStore';
+import {NetworkType} from 'src/types';
 
 const initialState: ChainApiContext = {
   status: 'unknown',
@@ -11,6 +12,8 @@ const initialState: ChainApiContext = {
   api: undefined,
   wsConnectionIndex: 0,
 };
+
+keyring.loadAll({store: keyringStore, type: 'sr25519'});
 
 export const ChainApiContext = createContext<ChainApiContext>(initialState);
 
@@ -43,11 +46,7 @@ export function ChainApiContextProvider({children}: {children: React.ReactNode})
 
     function handleReady() {
       logger.debug('ChainApiContext: Api ready at', wsAddress);
-      keyring.loadAll({
-        ss58Format: currentNetwork.ss58Format,
-        store: keyringStore,
-        type: 'sr25519',
-      });
+      keyring.setSS58Format(currentNetwork.ss58Format);
       dispatch({type: 'ON_READY', payload: apiPromise});
     }
 

--- a/src/context/ChainApiContext.tsx
+++ b/src/context/ChainApiContext.tsx
@@ -46,6 +46,7 @@ export function ChainApiContextProvider({children}: {children: React.ReactNode})
       keyring.loadAll({
         ss58Format: currentNetwork.ss58Format,
         store: keyringStore,
+        type: 'sr25519',
       });
       dispatch({type: 'ON_READY', payload: apiPromise});
     }

--- a/src/screen/AccountsScreen.tsx
+++ b/src/screen/AccountsScreen.tsx
@@ -1,5 +1,4 @@
 import Identicon from '@polkadot/reactnative-identicon';
-import {keyring} from '@polkadot/ui-keyring';
 import {NavigationProp} from '@react-navigation/native';
 import {Button, Divider, Icon, ListItem, MenuItem, OverflowMenu, Text, useTheme} from '@ui-kitten/components';
 import {Account, useAccounts} from 'context/AccountsContext';
@@ -35,8 +34,6 @@ export function AccountsScreen({navigation}: {navigation: NavigationProp<Complet
   const sortByFunction = sortBy === 'name' ? sortByDisplayName : sortByIsFavorite;
   const [sortMenuVisible, setSortMenuVisible] = React.useState(false);
 
-  const internalAccounts = keyring.getAccounts();
-
   return (
     <SafeView edges={noTopEdges}>
       {isLoading ? (
@@ -50,6 +47,7 @@ export function AccountsScreen({navigation}: {navigation: NavigationProp<Complet
           keyExtractor={(item) => item.account.address}
           renderItem={({item}) => (
             <AccountItem
+              isInternal={item.account.isInternal}
               identity={item.identity}
               isFavorite={item.account.isFavorite}
               toggleFavorite={() => toggleFavorite(item.account.address)}
@@ -130,14 +128,6 @@ export function AccountsScreen({navigation}: {navigation: NavigationProp<Complet
                 accessoryLeft={(p) => <Icon {...p} name="download-outline" />}>
                 Import account
               </Button>
-              <View>
-                <Text>{internalAccounts.length} internal accounts</Text>
-                {internalAccounts.map((account) => (
-                  <Text key={account.address} category="c1">
-                    {account.address}
-                  </Text>
-                ))}
-              </View>
             </View>
           )}
         />
@@ -181,6 +171,7 @@ function sortByIsFavorite(a: CombinedData, b: CombinedData) {
 }
 
 function AccountItem({
+  isInternal,
   identity,
   isFavorite,
   toggleFavorite,
@@ -188,10 +179,13 @@ function AccountItem({
 }: {
   identity: IdentityInfo;
   isFavorite: boolean;
+  isInternal: boolean;
   toggleFavorite: () => void;
   onPress: () => void;
 }) {
   const theme = useTheme();
+
+  console.log(isInternal);
 
   return (
     <ListItem
@@ -201,6 +195,7 @@ function AccountItem({
           <Identicon value={String(identity.accountId)} size={25} />
         </View>
       )}
+      description={`${isInternal ? 'Internal' : ''}`}
       title={(p) => (
         <View {...p}>
           <AccountInfoInlineTeaser identity={identity} />

--- a/src/screen/AddAccountScreen/AddAccountScreen.tsx
+++ b/src/screen/AddAccountScreen/AddAccountScreen.tsx
@@ -1,6 +1,5 @@
 import {NavigationProp} from '@react-navigation/native';
 import {Button, Divider, Icon, IconProps, Input, Layout, Tab, TabView, Text} from '@ui-kitten/components';
-import {useAccounts} from 'context/AccountsContext';
 import {ChainApiContext} from 'context/ChainApiContext';
 import {NetworkContext} from 'context/NetworkContext';
 import ModalTitle from 'presentational/ModalTitle';
@@ -14,6 +13,7 @@ import AddressInfoPreview from './AddressPreview';
 import {AppStackParamList} from 'src/navigation/navigation';
 import {default as globalStyles, monofontFamily, standardPadding} from 'src/styles';
 import {isAddressValid, parseAddress} from 'src/utils';
+import {keyring} from '@polkadot/ui-keyring';
 
 export function AddAccountScreen({navigation}: {navigation: NavigationProp<AppStackParamList>}) {
   const ref = useRef<Modalize>(null);
@@ -23,7 +23,6 @@ export function AddAccountScreen({navigation}: {navigation: NavigationProp<AppSt
 
   const {currentNetwork} = useContext(NetworkContext);
   const [state, dispatch] = useReducer(addAccountReducer, initialState);
-  const {addAccount} = useAccounts();
   const {api} = useContext(ChainApiContext);
 
   const handleInputChange = (text: string) => {
@@ -41,7 +40,7 @@ export function AddAccountScreen({navigation}: {navigation: NavigationProp<AppSt
     }
 
     if (state.step === 'preview') {
-      addAccount(currentNetwork.key, {address: state.address, name: '', isFavorite: false, isInternal: false});
+      keyring.addExternal(state.address, {name: '', network: currentNetwork.key});
       dispatch({type: 'SET_STEP', payload: 'success'});
       return;
     }
@@ -51,7 +50,7 @@ export function AddAccountScreen({navigation}: {navigation: NavigationProp<AppSt
 
       return;
     }
-  }, [addAccount, currentNetwork, navigation, state.address, state.step]);
+  }, [currentNetwork, navigation, state.address, state.step]);
 
   const handleScan = useCallback(
     ({data}) => {

--- a/src/screen/AddAccountScreen/AddAccountScreen.tsx
+++ b/src/screen/AddAccountScreen/AddAccountScreen.tsx
@@ -41,7 +41,7 @@ export function AddAccountScreen({navigation}: {navigation: NavigationProp<AppSt
     }
 
     if (state.step === 'preview') {
-      addAccount(currentNetwork.key, {address: state.address, name: '', isFavorite: false});
+      addAccount(currentNetwork.key, {address: state.address, name: '', isFavorite: false, isInternal: false});
       dispatch({type: 'SET_STEP', payload: 'success'});
       return;
     }

--- a/src/screen/CreateAccountScreen.tsx
+++ b/src/screen/CreateAccountScreen.tsx
@@ -15,9 +15,15 @@ import {keyring} from '@polkadot/ui-keyring';
 import {NavigationProp} from '@react-navigation/native';
 import {AccountsStackParamList} from 'src/navigation/navigation';
 import {accountsScreen} from 'src/navigation/routeKeys';
+import {useAccounts} from 'context/AccountsContext';
+import {NetworkContext} from 'context/NetworkContext';
 
 export function CreateAccountScreen({navigation}: {navigation: NavigationProp<AccountsStackParamList>}) {
   const theme = useTheme();
+
+  const {currentNetwork} = React.useContext(NetworkContext);
+  const {addAccount} = useAccounts();
+
   const [mnemonic] = React.useState(mnemonicGenerate());
   const [account, setAccount] = React.useState<{
     title: string;
@@ -39,7 +45,13 @@ export function CreateAccountScreen({navigation}: {navigation: NavigationProp<Ac
   );
 
   const onSubmit = () => {
-    keyring.addUri(mnemonic, account.password, {name: account.title});
+    const {json: key} = keyring.addUri(mnemonic, account.password, {name: account.title});
+    addAccount(currentNetwork.key, {
+      address: key.address,
+      name: key.meta.name as string,
+      isFavorite: false,
+      isInternal: true,
+    });
     navigation.navigate(accountsScreen, {reload: true});
   };
 

--- a/src/screen/CreateAccountScreen.tsx
+++ b/src/screen/CreateAccountScreen.tsx
@@ -15,15 +15,11 @@ import {keyring} from '@polkadot/ui-keyring';
 import {NavigationProp} from '@react-navigation/native';
 import {AccountsStackParamList} from 'src/navigation/navigation';
 import {accountsScreen} from 'src/navigation/routeKeys';
-import {useAccounts} from 'context/AccountsContext';
 import {NetworkContext} from 'context/NetworkContext';
 
 export function CreateAccountScreen({navigation}: {navigation: NavigationProp<AccountsStackParamList>}) {
   const theme = useTheme();
-
   const {currentNetwork} = React.useContext(NetworkContext);
-  const {addAccount} = useAccounts();
-
   const [mnemonic] = React.useState(mnemonicGenerate());
   const [account, setAccount] = React.useState<{
     title: string;
@@ -45,13 +41,7 @@ export function CreateAccountScreen({navigation}: {navigation: NavigationProp<Ac
   );
 
   const onSubmit = () => {
-    const {json: key} = keyring.addUri(mnemonic, account.password, {name: account.title});
-    addAccount(currentNetwork.key, {
-      address: key.address,
-      name: key.meta.name as string,
-      isFavorite: false,
-      isInternal: true,
-    });
+    keyring.addUri(mnemonic, account.password, {name: account.title, network: currentNetwork.key});
     navigation.navigate(accountsScreen, {reload: true});
   };
 

--- a/src/screen/DevScreen.tsx
+++ b/src/screen/DevScreen.tsx
@@ -139,6 +139,7 @@ function DevScreen() {
                       name: 'Manu. set Acct',
                       address: '167rjWHghVwBJ52mz8sNkqr5bKu5vpchbc9CBoieBhVX714h',
                       isFavorite: false,
+                      isInternal: false,
                     });
                     Alert.alert('Done');
                   }}>

--- a/src/screen/DevScreen.tsx
+++ b/src/screen/DevScreen.tsx
@@ -15,7 +15,7 @@ function DevScreen() {
   const [visible, setVisible] = useState(false);
 
   const {currentNetwork} = useContext(NetworkContext);
-  const {accounts, addAccount, removeAccount} = useAccounts();
+  const {accounts} = useAccounts();
   const {trigger} = useContext(InAppNotificationContext);
   const {status, api} = useContext(ChainApiContext);
   const [debugInfo, setDebugInfo] = useState('');
@@ -87,7 +87,7 @@ function DevScreen() {
             <Divider />
             {accounts.map((account) => (
               <View key={account.address}>
-                <ListItem
+                {/* <ListItem
                   title={`Remove account ${account.address}`}
                   description="Reset current stored accounts"
                   accessoryRight={() => (
@@ -100,7 +100,7 @@ function DevScreen() {
                       Trigger
                     </Button>
                   )}
-                />
+                /> */}
                 <Divider />
               </View>
             ))}
@@ -128,7 +128,7 @@ function DevScreen() {
                 <Divider />
               </View>
             ))}
-            <ListItem
+            {/* <ListItem
               title="Set Address"
               description="Manually set address"
               accessoryRight={() => (
@@ -146,7 +146,7 @@ function DevScreen() {
                   Trigger
                 </Button>
               )}
-            />
+            /> */}
             <Divider />
           </ScrollView>
         </Layout>

--- a/src/screen/ImportAccountScreen.tsx
+++ b/src/screen/ImportAccountScreen.tsx
@@ -3,7 +3,6 @@ import {keyring} from '@polkadot/ui-keyring';
 import {mnemonicValidate} from '@polkadot/util-crypto';
 import {NavigationProp, useNavigation} from '@react-navigation/native';
 import {Button, Icon, Input, ListItem, TopNavigationAction, useTheme} from '@ui-kitten/components';
-import {useAccounts} from 'context/AccountsContext';
 import {NetworkContext} from 'context/NetworkContext';
 import FormLabel from 'presentational/FormLabel';
 import Padder from 'presentational/Padder';
@@ -18,10 +17,7 @@ import zxcvbn from 'zxcvbn';
 
 export function ImportAccountScreen({navigation}: {navigation: NavigationProp<AccountsStackParamList>}) {
   const theme = useTheme();
-
   const {currentNetwork} = React.useContext(NetworkContext);
-  const {addAccount} = useAccounts();
-
   const [account, setAccount] = React.useState({title: '', password: '', confirmPassword: ''});
   const [isPasswordVisible, setIsPasswordVisible] = React.useState(false);
   const {seed, setSeed, address, isSeedValid} = useParseSeed();
@@ -37,13 +33,7 @@ export function ImportAccountScreen({navigation}: {navigation: NavigationProp<Ac
   );
 
   const onSubmit = () => {
-    const {json: key} = keyring.addUri(seed, account.password, {name: account.title});
-    addAccount(currentNetwork.key, {
-      address: key.address,
-      name: key.meta.name as string,
-      isFavorite: false,
-      isInternal: true,
-    });
+    keyring.addUri(seed, account.password, {name: account.title, network: currentNetwork.key});
     navigation.navigate(accountsScreen, {reload: true});
   };
 

--- a/src/screen/ImportAccountWithJsonFileScreen.tsx
+++ b/src/screen/ImportAccountWithJsonFileScreen.tsx
@@ -13,9 +13,15 @@ import {keyring} from '@polkadot/ui-keyring';
 import {NavigationProp} from '@react-navigation/core';
 import {AccountsStackParamList} from 'src/navigation/navigation';
 import {accountsScreen} from 'src/navigation/routeKeys';
+import {NetworkContext} from 'context/NetworkContext';
+import {useAccounts} from 'context/AccountsContext';
 
 export function ImportAccountWithJsonFileScreen({navigation}: {navigation: NavigationProp<AccountsStackParamList>}) {
   const theme = useTheme();
+
+  const {currentNetwork} = React.useContext(NetworkContext);
+  const {addAccount} = useAccounts();
+
   const [jsonContent, setJsonContent] = React.useState<string>();
   const [error, setError] = React.useState<string | undefined>(undefined);
   const parsedJson = jsonContent ? tryParseJson(jsonContent) : undefined;
@@ -24,7 +30,14 @@ export function ImportAccountWithJsonFileScreen({navigation}: {navigation: Navig
 
   function restoreAccount() {
     if (parsedJson && password) {
-      keyring.restoreAccount(parsedJson, password);
+      const pair = keyring.restoreAccount(parsedJson, password);
+      const pairJson = pair.toJson(password);
+      addAccount(currentNetwork.key, {
+        address: pairJson.address,
+        name: pairJson.meta.name as string,
+        isFavorite: false,
+        isInternal: true,
+      });
       navigation.navigate(accountsScreen, {reload: true});
     }
   }

--- a/src/screen/ImportAccountWithJsonFileScreen.tsx
+++ b/src/screen/ImportAccountWithJsonFileScreen.tsx
@@ -14,14 +14,10 @@ import {NavigationProp} from '@react-navigation/core';
 import {AccountsStackParamList} from 'src/navigation/navigation';
 import {accountsScreen} from 'src/navigation/routeKeys';
 import {NetworkContext} from 'context/NetworkContext';
-import {useAccounts} from 'context/AccountsContext';
 
 export function ImportAccountWithJsonFileScreen({navigation}: {navigation: NavigationProp<AccountsStackParamList>}) {
   const theme = useTheme();
-
   const {currentNetwork} = React.useContext(NetworkContext);
-  const {addAccount} = useAccounts();
-
   const [jsonContent, setJsonContent] = React.useState<string>();
   const [error, setError] = React.useState<string | undefined>(undefined);
   const parsedJson = jsonContent ? tryParseJson(jsonContent) : undefined;
@@ -31,13 +27,7 @@ export function ImportAccountWithJsonFileScreen({navigation}: {navigation: Navig
   function restoreAccount() {
     if (parsedJson && password) {
       const pair = keyring.restoreAccount(parsedJson, password);
-      const pairJson = pair.toJson(password);
-      addAccount(currentNetwork.key, {
-        address: pairJson.address,
-        name: pairJson.meta.name as string,
-        isFavorite: false,
-        isInternal: true,
-      });
+      keyring.saveAccountMeta(pair, {network: currentNetwork.key});
       navigation.navigate(accountsScreen, {reload: true});
     }
   }

--- a/src/screen/MyAccountScreen.tsx
+++ b/src/screen/MyAccountScreen.tsx
@@ -1,7 +1,7 @@
+import {keyring} from '@polkadot/ui-keyring';
 import {BN_ZERO} from '@polkadot/util';
 import {NavigationProp, RouteProp} from '@react-navigation/native';
 import {Text, useTheme} from '@ui-kitten/components';
-import {useAccounts} from 'context/AccountsContext';
 import Icon from 'presentational/Icon';
 import Padder from 'presentational/Padder';
 import SafeView, {noTopEdges} from 'presentational/SafeView';
@@ -24,7 +24,6 @@ export function MyAccountScreen({
   navigation: NavigationProp<CompleteNavigatorParamList>;
   route: RouteProp<AccountsStackParamList, typeof myIdentityScreen>;
 }) {
-  const {removeAccount} = useAccounts();
   const {data} = useAccountIdentityInfo(address);
   const formatBalance = useFormatBalance();
   const {data: accountInfo} = useAccountInfo(address);
@@ -84,7 +83,7 @@ export function MyAccountScreen({
               {
                 text: 'Delete',
                 onPress: () => {
-                  removeAccount(address);
+                  keyring.forgetAccount(address);
                   navigation.navigate(accountsScreen);
                 },
                 style: 'destructive',


### PR DESCRIPTION
<img align=right width=250 src=https://user-images.githubusercontent.com/16683923/137514483-d409c093-9441-4046-822d-8243d95971f7.png />

### Description
Showing internal accounts in Accounts screen.

Note:
Now every accounts action (add/import/import-json/remove/toggle favourite) is done through the ui-keyring.

So, the AccountsContext doesn't dispatch any accounts related action now. Alternatively it subscribe to the changes in the keyring and sets the accounts context for any change in the keyring.