### PR TITLE
Adding flow to sign transactions for internal accounts

### DIFF
--- a/src/context/AccountsContext.tsx
+++ b/src/context/AccountsContext.tsx
@@ -1,10 +1,10 @@
 import React, {useContext, createContext, useState, useEffect} from 'react';
 
+import {keyring} from '@polkadot/ui-keyring';
+import {VoidFn} from '@polkadot/api/types';
 import {SupportedNetworkType} from 'src/types';
 import {NetworkContext} from 'src/context/NetworkContext';
-import {keyring} from '@polkadot/ui-keyring';
-import {useApi} from './ChainApiContext';
-import {VoidFn} from '@polkadot/api/types';
+import {useApi} from 'src/context/ChainApiContext';
 
 export type Account = {
   address: string;

--- a/src/context/ChainApiContext.tsx
+++ b/src/context/ChainApiContext.tsx
@@ -4,7 +4,6 @@ import {createLogger} from 'src/utils';
 import {NetworkContext} from './NetworkContext';
 import {keyring} from '@polkadot/ui-keyring';
 import {keyringStore} from 'src/service/KeyringStore';
-import {NetworkType} from 'src/types';
 
 const initialState: ChainApiContext = {
   status: 'unknown',

--- a/src/context/TxContext/AuthenticateView.tsx
+++ b/src/context/TxContext/AuthenticateView.tsx
@@ -1,0 +1,67 @@
+import React, {useState} from 'react';
+import {Dimensions, StyleSheet} from 'react-native';
+import {Icon, IconProps, Layout, Input, Button, Text} from '@ui-kitten/components';
+import ModalTitle from 'presentational/ModalTitle';
+import Padder from 'presentational/Padder';
+import type {KeyringPair} from 'src/types';
+
+const {height} = Dimensions.get('window');
+
+const styles = StyleSheet.create({
+  container: {
+    height: height * 0.25,
+    justifyContent: 'center',
+    paddingHorizontal: 30,
+    paddingBottom: 50,
+  },
+});
+
+type Props = {
+  keyringPair: KeyringPair;
+  onAuthenticate: () => void;
+};
+
+export function AuthenticateView({onAuthenticate, keyringPair}: Props) {
+  const [password, setPassword] = useState('');
+  const [isValid, setIsValid] = useState<boolean | undefined>();
+
+  const onPressUnlock = () => {
+    try {
+      keyringPair.unlock(password);
+      setIsValid(true);
+      onAuthenticate();
+    } catch (e) {
+      setIsValid(false);
+    }
+  };
+
+  return (
+    <Layout style={styles.container}>
+      <ModalTitle title="Unlock Account" />
+      <Input
+        placeholder="Enter password"
+        secureTextEntry
+        value={password}
+        status={isValid === false ? 'danger' : 'basic'}
+        onChangeText={setPassword}
+        accessoryLeft={(props: IconProps) => <Icon {...props} name="lock-outline" />}
+        caption={isValid === false ? IncorrectPassword : undefined}
+      />
+      <Padder scale={1} />
+      <Button accessoryRight={(props) => <Icon {...props} name="unlock-outline" />} onPress={onPressUnlock}>
+        Unlock
+      </Button>
+    </Layout>
+  );
+}
+
+function IncorrectPassword() {
+  return (
+    <>
+      <Padder scale={0.5} />
+      <Text category="c2" status="danger">
+        Incorrect password
+      </Text>
+    </>
+  );
+}

--- a/src/context/TxContext/TxPreview.tsx
+++ b/src/context/TxContext/TxPreview.tsx
@@ -17,7 +17,7 @@ type PropTypes = {
   onCancel: () => void;
 };
 
-export function PreviewStep(props: PropTypes): React.ReactElement {
+export function TxPreview(props: PropTypes): React.ReactElement {
   const [open, setOpen] = useState(false);
   const theme = useTheme();
   const {transactionTitle, transactionInfo, partialFee, txPayload, params, onConfirm, onCancel} = props;

--- a/src/context/TxContext/TxPreview.tsx
+++ b/src/context/TxContext/TxPreview.tsx
@@ -15,12 +15,14 @@ type PropTypes = {
   partialFee: number;
   onConfirm: () => void;
   onCancel: () => void;
+  isExternalAccount: boolean;
 };
 
 export function TxPreview(props: PropTypes): React.ReactElement {
   const [open, setOpen] = useState(false);
   const theme = useTheme();
-  const {transactionTitle, transactionInfo, partialFee, txPayload, params, onConfirm, onCancel} = props;
+  const {transactionTitle, transactionInfo, partialFee, txPayload, params, onConfirm, onCancel, isExternalAccount} =
+    props;
 
   return (
     <Layout style={styles.container} level="1">
@@ -62,7 +64,7 @@ export function TxPreview(props: PropTypes): React.ReactElement {
             style={styles.submit}
             appearance="outline"
             onPress={onConfirm}
-            accessoryRight={(p) => <Icon {...p} name="video-outline" />}>
+            accessoryRight={isExternalAccount ? (p) => <Icon {...p} name="video-outline" /> : undefined}>
             Continue
           </Button>
         </Layout>

--- a/src/service/AsyncSigner.ts
+++ b/src/service/AsyncSigner.ts
@@ -1,7 +1,7 @@
 import type {Signer, SignerResult} from '@polkadot/api/types';
 import type {SignerPayloadJSON} from '@polkadot/types/types';
 
-export default class QrSigner implements Signer {
+export default class AsyncSigner implements Signer {
   readonly promise: (payload: SignerPayloadJSON) => Promise<SignerResult>;
 
   constructor(createPromise: (payload: SignerPayloadJSON) => Promise<SignerResult>) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,7 @@
 import {DeriveAccountRegistration} from '@polkadot/api-derive/types';
 import {Registration} from '@polkadot/types/interfaces';
 import {BarCodeReadEvent} from 'react-native-camera';
+import {keyring} from '@polkadot/ui-keyring';
 
 export type SupportedNetworkType = 'ethereum' | 'polkadot' | 'kusama' | 'litentry_test';
 
@@ -66,3 +67,5 @@ export interface AddressIdentity extends DeriveAccountRegistration {
   isExistent: boolean;
   waitCount: number;
 }
+
+export type KeyringPair = ReturnType<typeof keyring.getPair>;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -15,7 +15,6 @@ import {
 import {blake2AsU8a, checkAddress, decodeAddress, isEthereumChecksum} from '@polkadot/util-crypto';
 import {SignerPayloadJSON} from '@polkadot/types/types';
 import {ExtrinsicPayload} from '@polkadot/types/interfaces';
-import {keyring} from '@polkadot/ui-keyring';
 import registry from 'src/typeRegistry';
 import {AccountAddressType, NetworkType} from './types';
 import {trim} from 'lodash';
@@ -206,12 +205,4 @@ export function validateFormField(
 // the types after the filter would not include the empty values
 export function notEmpty<TValue>(value: TValue | null | undefined | ''): value is TValue {
   return value !== null && value !== undefined && value !== '';
-}
-
-export function getPair(address: string) {
-  try {
-    return keyring.getPair(address);
-  } catch (e) {
-    return undefined;
-  }
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -15,6 +15,7 @@ import {
 import {blake2AsU8a, checkAddress, decodeAddress, isEthereumChecksum} from '@polkadot/util-crypto';
 import {SignerPayloadJSON} from '@polkadot/types/types';
 import {ExtrinsicPayload} from '@polkadot/types/interfaces';
+import {keyring} from '@polkadot/ui-keyring';
 import registry from 'src/typeRegistry';
 import {AccountAddressType, NetworkType} from './types';
 import {trim} from 'lodash';
@@ -205,4 +206,12 @@ export function validateFormField(
 // the types after the filter would not include the empty values
 export function notEmpty<TValue>(value: TValue | null | undefined | ''): value is TValue {
   return value !== null && value !== undefined && value !== '';
+}
+
+export function getPair(address: string) {
+  try {
+    return keyring.getPair(address);
+  } catch (e) {
+    return undefined;
+  }
 }


### PR DESCRIPTION
It works exactly the same as for external accounts (how we currently sign transactions) but without the screens for scanning the QR codes. 
 
If the internal account is locked, the user has to enter the password in a form.

<img width="383" alt="Screenshot 2021-10-19 at 11 22 44 AM" src="https://user-images.githubusercontent.com/8374946/137906104-220a1f04-320e-49a0-8232-73dd30bc9a7e.png">

<img width="380" alt="Screenshot 2021-10-19 at 11 23 49 AM" src="https://user-images.githubusercontent.com/8374946/137906134-fc4e6c15-47f4-4e6d-a9ce-5f43edd924f8.png">

For internal accounts, pressing continue after the preview will send the transaction showing the submitting view as usual.

<img width="390" alt="Screenshot 2021-10-19 at 12 23 43 PM" src="https://user-images.githubusercontent.com/8374946/137906268-beb01957-0c62-4876-a344-4b548c63a14a.png">


