### PR TITLE
Adding Drawer Footer (with app version)

### DIFF
--- a/src/screen/Drawer/DrawerScreen.tsx
+++ b/src/screen/Drawer/DrawerScreen.tsx
@@ -20,6 +20,8 @@ import {
   parachainsOverviewScreen,
 } from 'src/navigation/routeKeys';
 import globalStyles, {monofontFamily, standardPadding} from 'src/styles';
+import {appVersion} from 'src/service/Device';
+import {getCurrentYear} from 'src/utils';
 
 function DrawerScreen({navigation}: DrawerContentComponentProps) {
   const {theme, toggleTheme} = useTheme();
@@ -122,8 +124,18 @@ function DrawerScreen({navigation}: DrawerContentComponentProps) {
             </>
           )}
         </Layout>
+        <Footer />
       </Layout>
     </SafeView>
+  );
+}
+
+function Footer() {
+  return (
+    <View style={styles.footer}>
+      <Text category="c2">{`© ${getCurrentYear()} Litentry Technologies GmbH`}</Text>
+      <Text category="c2">{`Version ${appVersion()}`}</Text>
+    </View>
   );
 }
 
@@ -152,6 +164,7 @@ const styles = StyleSheet.create({
     paddingLeft: 12,
     backgroundColor: undefined,
   },
+  footer: {alignItems: 'center', paddingVertical: 15},
 });
 
 export default DrawerScreen;

--- a/src/service/Device.ts
+++ b/src/service/Device.ts
@@ -23,3 +23,5 @@ export const getReadableVersion = () => {
   const code = Platform.OS === 'ios' ? ` (${Device.getBuildNumber()})` : '';
   return `${Device.getVersion()}${code}`;
 };
+
+export const appVersion = () => `${Device.getVersion()} [${Device.getBuildNumber()}]`;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -208,3 +208,7 @@ export function validateFormField(
 export function notEmpty<TValue>(value: TValue | null | undefined | ''): value is TValue {
   return value !== null && value !== undefined && value !== '';
 }
+
+export function getCurrentYear() {
+  return new Date().getFullYear();
+}


### PR DESCRIPTION
Adding the app version to the footer so we can get better feedback from users.

<img width="384" alt="Screenshot 2021-11-22 at 11 19 39 AM" src="https://user-images.githubusercontent.com/8374946/142851921-820697f3-5316-4906-a30b-d5b9f7cab39a.png">


