### PR TITLE
Revert "Bump react-native-gesture-handler from 1.10.3 to 2.1.0"

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -384,7 +384,7 @@ PODS:
     - RNFBApp
   - RNFS (2.18.0):
     - React
-  - RNGestureHandler (2.1.0):
+  - RNGestureHandler (1.10.3):
     - React-Core
   - RNKeychain (8.0.0):
     - React-Core
@@ -706,7 +706,7 @@ SPEC CHECKSUMS:
   RNFBApp: d11e8ae04b9b6230f3a28b70761f2edd185deaa8
   RNFBMessaging: dd0bd7d837b7b6b8e881248a2639af5dc36b28ef
   RNFS: 3ab21fa6c56d65566d1fb26c2228e2b6132e5e32
-  RNGestureHandler: e5c7cab5f214503dcefd6b2b0cefb050e1f51c4a
+  RNGestureHandler: a479ebd5ed4221a810967000735517df0d2db211
   RNKeychain: 4f63aada75ebafd26f4bc2c670199461eab85d94
   RNPermissions: 7043bacbf928eae25808275cfe73799b8f618911
   RNReactNativeHapticFeedback: b83bfb4b537bdd78eb4f6ffe63c6884f7b049ead

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "react-native-device-info": "^8.4.8",
     "react-native-document-picker": "^7.1.1",
     "react-native-fs": "^2.18.0",
-    "react-native-gesture-handler": "^2.1.0",
+    "react-native-gesture-handler": "^1.8.0",
     "react-native-haptic-feedback": "^1.13.0",
     "react-native-in-app-message": "^1.0.32",
     "react-native-keychain": "^8.0.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,5 @@
 import React from 'react';
-import {StyleSheet} from 'react-native';
 import {SafeAreaProvider} from 'react-native-safe-area-context';
-import {GestureHandlerRootView} from 'react-native-gesture-handler';
 import {QueryClient, QueryClientProvider} from 'react-query';
 import {IconRegistry} from '@ui-kitten/components';
 import {EvaIconsPack} from '@ui-kitten/eva-icons';
@@ -23,7 +21,7 @@ const queryClient = new QueryClient();
 
 export default function App() {
   return (
-    <GestureHandlerRootView style={styles.appContainer}>
+    <>
       <IconRegistry icons={[EvaIconsPack, IonicIconsPack]} />
       <QueryClientProvider client={queryClient}>
         <NavigationContainer>
@@ -46,12 +44,6 @@ export default function App() {
           </NetworkContextProvider>
         </NavigationContainer>
       </QueryClientProvider>
-    </GestureHandlerRootView>
+    </>
   );
 }
-
-const styles = StyleSheet.create({
-  appContainer: {
-    flex: 1,
-  },
-});

--- a/yarn.lock
+++ b/yarn.lock
@@ -8301,15 +8301,15 @@ react-native-fs@^2.18.0:
     base-64 "^0.1.0"
     utf8 "^3.0.0"
 
-react-native-gesture-handler@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/react-native-gesture-handler/-/react-native-gesture-handler-2.1.0.tgz#be7a83a7bd340a2316551a4d30d7abf06b46c1da"
-  integrity sha512-vF4yEUrV5GMBioTkvf5Le1l3N/52dSLBnNMFC+kZ4hssnRoXB0hEQ0ReUkZckRB5L3nbHBhAyjySEtFPx4nyEA==
+react-native-gesture-handler@^1.8.0:
+  version "1.10.3"
+  resolved "https://registry.yarnpkg.com/react-native-gesture-handler/-/react-native-gesture-handler-1.10.3.tgz#942bbf2963bbf49fa79593600ee9d7b5dab3cfc0"
+  integrity sha512-cBGMi1IEsIVMgoox4RvMx7V2r6bNKw0uR1Mu1o7NbuHS6BRSVLq0dP34l2ecnPlC+jpWd3le6Yg1nrdCjby2Mw==
   dependencies:
     "@egjs/hammerjs" "^2.0.17"
+    fbjs "^3.0.0"
     hoist-non-react-statics "^3.3.0"
     invariant "^2.2.4"
-    lodash "^4.17.21"
     prop-types "^15.7.2"
 
 react-native-haptic-feedback@^1.13.0:


### PR DESCRIPTION
Reverts litentry/litentry-app#677

[react-native-modalize](https://github.com/jeremybarbet/react-native-modalize) does not support v2 of react-native-gesture-handler. Will have to wait until it's fixed or use another library like [react-native-bottom-sheet](https://github.com/gorhom/react-native-bottom-sheet)