### PR TITLE
Material design's loading indicator

### DIFF
--- a/src/ui/components/LoadingView.tsx
+++ b/src/ui/components/LoadingView.tsx
@@ -1,12 +1,13 @@
 import React, {ReactNode} from 'react';
-import {StyleSheet, ActivityIndicator, ActivityIndicatorProps} from 'react-native';
-import {Layout, Text} from '@ui-kitten/components';
+import {StyleSheet} from 'react-native';
+import {Layout} from '@ui/components/Layout';
+import {Text, ActivityIndicator} from '@ui/library';
 import globalStyles, {standardPadding, monofontFamily, colorGreen} from '@ui/styles';
 
 type PropTypes = {
   text?: string;
   renderIcon?: () => ReactNode;
-  size?: ActivityIndicatorProps['size'];
+  size?: React.ComponentProps<typeof ActivityIndicator>['size'];
   appearance?: 'secondary' | 'primary';
 };
 
@@ -19,7 +20,7 @@ function LoadingView(props: PropTypes) {
         {renderIcon && renderIcon()}
         <Text style={[styles.text, renderIcon ? styles.withIcon : {}, styles[appearance || 'primary']]}>{text}</Text>
       </Layout>
-      <ActivityIndicator size={size || 'large'} color={colorGreen} />
+      <ActivityIndicator size={size || 'large'} color={colorGreen} animating />
     </Layout>
   );
 }

--- a/src/ui/screens/ApiLoadingScreen.tsx
+++ b/src/ui/screens/ApiLoadingScreen.tsx
@@ -1,5 +1,5 @@
 import React, {useContext} from 'react';
-import {ActivityIndicator, StyleSheet, TouchableOpacity, View} from 'react-native';
+import {StyleSheet, TouchableOpacity, View} from 'react-native';
 import {CompositeNavigationProp} from '@react-navigation/native';
 import {StackNavigationProp} from '@react-navigation/stack';
 import {Icon, Text} from '@ui-kitten/components';
@@ -9,7 +9,7 @@ import {noop} from 'lodash';
 import NetworkItem from '@ui/components/NetworkItem';
 import {ApiLoadingStackParamList, RootStackParamList} from '@ui/navigation/navigation';
 import {appStack, networkSelectionScreen} from '@ui/navigation/routeKeys';
-import {AppBar, AppHeader} from '@ui/library';
+import {AppBar, AppHeader, ActivityIndicator} from '@ui/library';
 import {Layout} from '@ui/components/Layout';
 import globalStyles, {colorGreen, monofontFamily, standardPadding} from '@ui/styles';
 
@@ -50,7 +50,7 @@ export function ApiLoadingScreen({navigation}: PropTypes) {
             {`${inProgress ? 'Connecting' : 'Connected'}`} to {currentNetwork?.name ?? ''}
           </Text>
         </View>
-        {inProgress ? <ActivityIndicator size={'large'} color={colorGreen} /> : null}
+        {inProgress ? <ActivityIndicator size={'large'} color={colorGreen} animating /> : null}
       </View>
     </Layout>
   );

--- a/src/ui/screens/Parachains/ParachainAuctionsScreen.tsx
+++ b/src/ui/screens/Parachains/ParachainAuctionsScreen.tsx
@@ -17,7 +17,7 @@ import {ActivityIndicator, Caption, DataTable, Text} from '@ui/library';
 import {Layout} from '@ui/components/Layout';
 import {Padder} from '@ui/components/Padder';
 import {useTheme} from '@ui/library';
-import globalStyles, {standardPadding} from '@ui/styles';
+import globalStyles, {colorGreen, standardPadding} from '@ui/styles';
 
 export function ParachainsAuctionsScreen() {
   const {data, isLoading: auctionInfoIsLoading, isError: auctionIsError} = useAuctionInfo();
@@ -192,7 +192,7 @@ const DataTableComp = (props: DataTableProps) => {
 
       {loading ? (
         <View style={globalStyles.paddedContainer}>
-          <ActivityIndicator />
+          <ActivityIndicator color={colorGreen} animating />
         </View>
       ) : (
         pageItems.map((item) => (

--- a/src/ui/screens/Polkassembly/PolkassemblyDiscussions.tsx
+++ b/src/ui/screens/Polkassembly/PolkassemblyDiscussions.tsx
@@ -7,12 +7,13 @@ import {Label} from '@ui/components/Label';
 import LoadingView from '@ui/components/LoadingView';
 import SafeView, {noTopEdges} from '@ui/components/SafeView';
 import * as React from 'react';
-import {ActivityIndicator, FlatList, StyleSheet, TouchableOpacity, View} from 'react-native';
+import {FlatList, StyleSheet, TouchableOpacity, View} from 'react-native';
 import {OrderByType, topicIdMap, usePolkassemblyDiscussions} from 'src/api/hooks/usePolkassemblyDiscussions';
 import {PolkassemblyDiscussionStackParamList} from '@ui/navigation/navigation';
 import {polkassemblyDiscussionDetail} from '@ui/navigation/routeKeys';
 import {Padder} from '@ui/components/Padder';
-import globalStyles, {standardPadding} from '@ui/styles';
+import {ActivityIndicator} from '@ui/library';
+import globalStyles, {standardPadding, colorGreen} from '@ui/styles';
 
 export function PolkassemblyDiscussions({
   navigation,
@@ -131,7 +132,7 @@ export function PolkassemblyDiscussions({
             <View style={styles.footer}>
               {hasNextPage ? (
                 isFetching || isFetchingNextPage ? (
-                  <ActivityIndicator />
+                  <ActivityIndicator color={colorGreen} animating />
                 ) : (
                   <Button onPress={() => fetchNextPage()}>Load more ...</Button>
                 )


### PR DESCRIPTION
This PR makes use of the `ActivityIndicator` from `react-native-paper` as well as replacing some components from UI Kitten

Fixes #620 