### PR TITLE
Exposing a single useTheme hook across the app

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -23,6 +23,16 @@ module.exports = {
             importNames: ['formatBalance'],
             message: 'Please use useFormatBalance hook instead.',
           },
+          {
+            name: 'react-native-paper',
+            importNames: ['useTheme'],
+            message: 'Please import useTheme from @ui/library instead.',
+          },
+          {
+            name: '@react-navigation/native',
+            importNames: ['useTheme'],
+            message: 'Please import useTheme from @ui/library instead.',
+          },
         ],
       },
     ],

--- a/src/context/NavigationContainer.tsx
+++ b/src/context/NavigationContainer.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import {NavigationContainer as RNnavigationContainer} from '@react-navigation/native';
-import {useTheme} from 'src/context/ThemeContext';
+import {useToggleTheme} from 'src/context/ThemeContext';
 import {darkTheme, lightTheme} from '@ui/navigation/theme';
 import {linking} from '@ui/navigation/routeKeys';
 import SplashScreen from 'react-native-splash-screen';
@@ -10,7 +10,7 @@ type PropTypes = {
 };
 
 export function NavigationContainer({children}: PropTypes) {
-  const {theme} = useTheme();
+  const {theme} = useToggleTheme();
 
   return (
     <RNnavigationContainer

--- a/src/context/ThemeContext.tsx
+++ b/src/context/ThemeContext.tsx
@@ -6,7 +6,7 @@ import {mapping} from '@eva-design/material';
 import {usePersistedState} from '@hooks/usePersistedState';
 import customMapping from 'src/mapping.json';
 import {darkMaterialThemeOverride, lightMaterialThemeOverride} from '@ui/navigation/theme';
-import {Provider as PaperProvider, useTheme as useRNPaperTheme} from '@ui/library';
+import {Provider as PaperProvider} from '@ui/library';
 import {themeDark, themeLight} from '@ui/library/theme';
 
 type Theme = 'light' | 'dark';
@@ -52,13 +52,12 @@ export default function ThemeProvider({children}: PropTypes) {
   );
 }
 
-export function useTheme() {
-  const rnPaperTheme = useRNPaperTheme();
+export function useToggleTheme() {
   const context = useContext(ThemeContext);
 
   if (!context) {
     throw new Error('useTheme must be used within a ThemeProvider');
   }
 
-  return {...context, ...rnPaperTheme};
+  return context;
 }

--- a/src/ui/components/NetworkItem.tsx
+++ b/src/ui/components/NetworkItem.tsx
@@ -1,8 +1,7 @@
 import React from 'react';
 import {StyleSheet, View} from 'react-native';
 import {NetworkType} from 'src/types';
-import {Icon, Text} from '@ui/library';
-import {useTheme} from 'context/ThemeContext';
+import {Icon, Text, useTheme} from '@ui/library';
 import {Padder} from '@ui/components/Padder';
 
 type PropTypes = {item: NetworkType; isConnected: boolean};

--- a/src/ui/library/Icon.tsx
+++ b/src/ui/library/Icon.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import MaterialCommunityIcons, {default as VectorIcon} from 'react-native-vector-icons/MaterialCommunityIcons';
-import {useTheme} from 'react-native-paper';
+import {useTheme} from '@ui/library';
 
 type IconProps = {
   name: typeof MaterialCommunityIcons['name'];

--- a/src/ui/library/Modal.tsx
+++ b/src/ui/library/Modal.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import {StyleSheet} from 'react-native';
-import {Modal as RNPaperModal, Portal, useTheme} from 'react-native-paper';
+import {Modal as RNPaperModal, Portal} from 'react-native-paper';
+import {useTheme} from '@ui/library';
 
 type ModalProps = {
   visible: boolean;

--- a/src/ui/library/index.ts
+++ b/src/ui/library/index.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-imports */
 /**
  *  This is the entry point for third party libraries (UI).
  *  All components from a third party library should be exported here.

--- a/src/ui/navigation/AppBars.tsx
+++ b/src/ui/navigation/AppBars.tsx
@@ -7,9 +7,8 @@ import {useApi} from 'context/ChainApiContext';
 import {NetworkContext} from 'context/NetworkContext';
 import NetworkItem from '@ui/components/NetworkItem';
 import {networkSelectionScreen} from '@ui/navigation/routeKeys';
-import {AppBar, AppHeader, Title} from '@ui/library';
+import {AppBar, AppHeader, Title, useTheme} from '@ui/library';
 import {standardPadding} from '@ui/styles';
-import {useTheme} from 'context/ThemeContext';
 
 export function MainDrawerAppBar({
   navigation,

--- a/src/ui/screens/Drawer/DrawerScreen.tsx
+++ b/src/ui/screens/Drawer/DrawerScreen.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {Image, StyleSheet, TouchableOpacity, View, ScrollView} from 'react-native';
 import {DrawerContentComponentProps} from '@react-navigation/drawer';
-import {useTheme} from 'context/ThemeContext';
+import {useToggleTheme} from 'context/ThemeContext';
 import logo from 'image/logo.png';
 import SafeView from '@ui/components/SafeView';
 import {useIsParachainAvailable} from 'src/api/hooks/useIsParachainAvailable';
@@ -25,7 +25,7 @@ import {getCurrentYear} from 'src/utils/date';
 import {Drawer, Switch, Text, Divider} from '@ui/library';
 
 function DrawerScreen({navigation}: DrawerContentComponentProps) {
-  const {theme, toggleTheme} = useTheme();
+  const {theme, toggleTheme} = useToggleTheme();
   const isParachainAvailable = useIsParachainAvailable();
   const [activeScreen, setActiveScreen] = React.useState<string>(dashboardScreen);
 

--- a/src/ui/screens/MyAccountScreen.tsx
+++ b/src/ui/screens/MyAccountScreen.tsx
@@ -7,7 +7,7 @@ import Identicon from '@polkadot/reactnative-identicon';
 import {useAccounts} from 'context/AccountsContext';
 import {Padder} from '@ui/components/Padder';
 import SafeView, {noTopEdges} from '@ui/components/SafeView';
-import {Button, Caption, IconButton, IconSource, Card, Snackbar} from '@ui/library';
+import {Button, Caption, IconButton, IconSource, Card, Snackbar, useTheme} from '@ui/library';
 import {ScrollView} from 'react-native-gesture-handler';
 import {useAccountIdentityInfo} from 'src/api/hooks/useAccountIdentityInfo';
 import {useAccountInfo} from 'src/api/hooks/useAccountInfo';
@@ -23,7 +23,6 @@ import {
   sendFundScreen,
 } from '@ui/navigation/routeKeys';
 import {standardPadding} from '@ui/styles';
-import {useTheme} from 'context/ThemeContext';
 
 export function MyAccountScreen({
   navigation,


### PR DESCRIPTION
Currently there are 5 different `useTheme` functions that can be imported from different places: `@react-nativation/native`, `@ui-kitten/components`, `react-native-paper`, `@ui/library` and `ThemeContext`. This can lead to confusion. 

This PR aims to fix that, adding eslint rules to prevent importing the function from the third party libraries and making `ThemeContext` to only expose `toggleTheme` and `theme` value so only `useTheme` from `@ui/library` can be used.

Since `@ui-kitten` is going to be removed, there is no need to add an eslint rule for it.