### PR TITLE
Fix linting workflow

### DIFF
--- a/.github/workflows/code-style-lint.yml
+++ b/.github/workflows/code-style-lint.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   lint:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it


### PR DESCRIPTION
Fixes:
```
Can't find any online and idle self-hosted runner in the current repository, account/organization that matches the required labels: 'self-hosted'
Waiting for a runner to pick up this job...
```