### PR TITLE
Issue 824 makes the links in member profile clickable

### DIFF
--- a/src/ui/screens/Council/CandidateScreen.tsx
+++ b/src/ui/screens/Council/CandidateScreen.tsx
@@ -1,5 +1,5 @@
 import React, {useEffect} from 'react';
-import {View, FlatList} from 'react-native';
+import {View, FlatList, Linking, StyleSheet} from 'react-native';
 import {NavigationProp, RouteProp} from '@react-navigation/native';
 import {Divider, List, Card, Icon, Caption, Subheading, Paragraph} from '@ui/library';
 import IdentityIcon from '@polkadot/reactnative-identicon';
@@ -87,7 +87,7 @@ export function CandidateScreen({route, navigation}: ScreenProps) {
                     left={() => <LeftIcon icon="email-outline" />}
                     right={() => (
                       <ItemRight>
-                        <Caption>{email}</Caption>
+                        <Caption selectable>{email}</Caption>
                       </ItemRight>
                     )}
                   />
@@ -98,7 +98,11 @@ export function CandidateScreen({route, navigation}: ScreenProps) {
                     left={() => <LeftIcon icon="twitter" />}
                     right={() => (
                       <ItemRight>
-                        <Caption>{twitter}</Caption>
+                        <Caption
+                          style={styles.twitter}
+                          onPress={() => Linking.openURL('https://twitter.com/' + twitter)}>
+                          {twitter}
+                        </Caption>
                       </ItemRight>
                     )}
                   />
@@ -109,7 +113,9 @@ export function CandidateScreen({route, navigation}: ScreenProps) {
                     left={() => <LeftIcon icon="message-outline" />}
                     right={() => (
                       <ItemRight>
-                        <Caption>{riot}</Caption>
+                        <Caption style={styles.matrix} onPress={() => Linking.openURL('https://matrix.to/#/' + riot)}>
+                          {riot}
+                        </Caption>
                       </ItemRight>
                     )}
                   />
@@ -120,7 +126,9 @@ export function CandidateScreen({route, navigation}: ScreenProps) {
                     left={() => <LeftIcon icon="earth" />}
                     right={() => (
                       <ItemRight>
-                        <Caption>{web}</Caption>
+                        <Caption style={styles.web} onPress={() => Linking.openURL(web)}>
+                          {web}
+                        </Caption>
                       </ItemRight>
                     )}
                   />
@@ -168,3 +176,15 @@ function Voter({accountId}: {accountId: AccountId}) {
     />
   );
 }
+
+const styles = StyleSheet.create({
+  twitter: {
+    color: '#1DA1F2',
+  },
+  matrix: {
+    color: '#238cf5',
+  },
+  web: {
+    textDecorationLine: 'underline',
+  },
+});

--- a/src/ui/screens/Council/CandidateScreen.tsx
+++ b/src/ui/screens/Council/CandidateScreen.tsx
@@ -14,6 +14,7 @@ import {Padder} from '@ui/components/Padder';
 import globalStyles from '@ui/styles';
 import {useFormatBalance} from 'src/api/hooks/useFormatBalance';
 import {useCouncilVotesOf} from 'src/api/hooks/useCouncilVotesOf';
+import {useTheme} from '@ui/library';
 
 type ScreenProps = {
   navigation: NavigationProp<DashboardStackParamList>;
@@ -38,6 +39,7 @@ export function CandidateScreen({route, navigation}: ScreenProps) {
   const screenTitle = route.params.title;
   const {data: councilData, isLoading: isLoadingCouncil} = useCouncil();
   const {data: identityInfoData, isLoading: isLoadingIdentityInfo} = useAccountIdentityInfo(accountId);
+  const {colors} = useTheme();
 
   useEffect(() => {
     if (screenTitle) {
@@ -99,8 +101,8 @@ export function CandidateScreen({route, navigation}: ScreenProps) {
                     right={() => (
                       <ItemRight>
                         <Caption
-                          style={styles.twitter}
-                          onPress={() => Linking.openURL('https://twitter.com/' + twitter)}>
+                          style={{color: colors.primary}}
+                          onPress={() => Linking.openURL(`https://twitter.com/${twitter}`)}>
                           {twitter}
                         </Caption>
                       </ItemRight>
@@ -113,7 +115,9 @@ export function CandidateScreen({route, navigation}: ScreenProps) {
                     left={() => <LeftIcon icon="message-outline" />}
                     right={() => (
                       <ItemRight>
-                        <Caption style={styles.matrix} onPress={() => Linking.openURL('https://matrix.to/#/' + riot)}>
+                        <Caption
+                          style={{color: colors.primary}}
+                          onPress={() => Linking.openURL(`https://matrix.to/#/${riot}`)}>
                           {riot}
                         </Caption>
                       </ItemRight>
@@ -178,12 +182,6 @@ function Voter({accountId}: {accountId: AccountId}) {
 }
 
 const styles = StyleSheet.create({
-  twitter: {
-    color: '#1DA1F2',
-  },
-  matrix: {
-    color: '#238cf5',
-  },
   web: {
     textDecorationLine: 'underline',
   },


### PR DESCRIPTION
Now council members' profiles are clickable based on Twitter/web/matrix while selecting email.

![Screenshot_1644421235](https://user-images.githubusercontent.com/22363352/153239527-c7bbcb5a-7c1d-4788-a9fd-c6cb89ee4ae7.png)
![Screenshot_1644421883](https://user-images.githubusercontent.com/22363352/153239566-342004b2-c320-4820-9b67-f9e3dffaee0b.png)

