### PR TITLE
Adding pull to refresh to the dashboard

### DIFF
--- a/src/api/hooks/useBountiesSummary.ts
+++ b/src/api/hooks/useBountiesSummary.ts
@@ -1,7 +1,7 @@
 import {gql, useQuery} from '@apollo/client';
 import type {ProxyBountiesSummary} from 'src/generated/litentryGraphQLTypes';
 
-const BOUNTIES_SUMMARY_QUERY = gql`
+export const BOUNTIES_SUMMARY_QUERY = gql`
   query getBountiesSummary {
     proxyBountiesSummary {
       activeBounties

--- a/src/api/hooks/useCouncilSummary.tsx
+++ b/src/api/hooks/useCouncilSummary.tsx
@@ -3,7 +3,7 @@ import {ProxyCouncil} from 'src/generated/litentryGraphQLTypes';
 
 export type CouncilSummary = Omit<ProxyCouncil, 'members' | 'runnersUp' | 'candidates'>;
 
-const COUNCIL_SUMMARY_QUERY = gql`
+export const COUNCIL_SUMMARY_QUERY = gql`
   query getCouncilSummary {
     proxyCouncil {
       primeMember {

--- a/src/api/hooks/useDemocracySummary.ts
+++ b/src/api/hooks/useDemocracySummary.ts
@@ -3,7 +3,7 @@ import {ProxyDemocracySummary} from 'src/generated/litentryGraphQLTypes';
 
 export type DemocracySummary = ProxyDemocracySummary;
 
-const DEMOCRACY_SUMMARY_QUERY = gql`
+export const DEMOCRACY_SUMMARY_QUERY = gql`
   query getDemocracySummary {
     proxyDemocracySummary {
       activeProposals

--- a/src/api/hooks/useRefetch.ts
+++ b/src/api/hooks/useRefetch.ts
@@ -1,0 +1,24 @@
+import {useCallback, useState} from 'react';
+import {useLitentryApiClient} from 'context/LitentryApiContext';
+import type {DocumentNode} from '@apollo/client';
+
+export type RefetchQueries = Array<DocumentNode> | 'active' | 'all';
+
+export function useRefetch(queries?: RefetchQueries) {
+  const {client} = useLitentryApiClient();
+  const [refreshing, setRefreshing] = useState(false);
+
+  const refetch = useCallback(async () => {
+    setRefreshing(true);
+    client
+      .refetchQueries({include: queries ?? 'active'})
+      .catch((error) => {
+        if (__DEV__) {
+          console.error(error);
+        }
+      })
+      .finally(() => setRefreshing(false));
+  }, [client, queries]);
+
+  return {refreshing, refetch};
+}

--- a/src/api/hooks/useRefetch.ts
+++ b/src/api/hooks/useRefetch.ts
@@ -4,14 +4,14 @@ import type {DocumentNode} from '@apollo/client';
 
 export type RefetchQueries = Array<DocumentNode> | 'active' | 'all';
 
-export function useRefetch(queries?: RefetchQueries) {
+export function useRefetch(queries: RefetchQueries = 'active') {
   const {client} = useLitentryApiClient();
   const [refreshing, setRefreshing] = useState(false);
 
   const refetch = useCallback(async () => {
     setRefreshing(true);
     client
-      .refetchQueries({include: queries ?? 'active'})
+      .refetchQueries({include: queries})
       .catch((error) => {
         if (__DEV__) {
           console.error(error);

--- a/src/context/LitentryApiContext.tsx
+++ b/src/context/LitentryApiContext.tsx
@@ -8,6 +8,7 @@ const LITENTRY_API_URI = 'https://graph.litentry.io/graphql';
 
 type LitentryApiContextType = {
   clearCache: () => void;
+  client: ApolloClient<NormalizedCacheObject>;
 };
 
 const LitentryApiContext = React.createContext<LitentryApiContextType | undefined>(undefined);
@@ -63,7 +64,7 @@ export function LitentryApiClientProvider({children}: {children: React.ReactNode
 
   return (
     <ApolloProvider client={client}>
-      <LitentryApiContext.Provider value={{clearCache}}>{children}</LitentryApiContext.Provider>
+      <LitentryApiContext.Provider value={{clearCache, client}}>{children}</LitentryApiContext.Provider>
     </ApolloProvider>
   );
 }
@@ -71,7 +72,15 @@ export function LitentryApiClientProvider({children}: {children: React.ReactNode
 export function useClearCache() {
   const context = useContext(LitentryApiContext);
   if (!context) {
-    throw new Error('useLitentryApiClient must be used within LitentryApiClientProvider');
+    throw new Error('useClearCache must be used within LitentryApiClientProvider');
   }
   return {clearCache: context.clearCache};
+}
+
+export function useLitentryApiClient() {
+  const context = useContext(LitentryApiContext);
+  if (!context) {
+    throw new Error('useClient must be used within LitentryApiClientProvider');
+  }
+  return {client: context.client};
 }

--- a/src/ui/components/BountySummaryTeaser.tsx
+++ b/src/ui/components/BountySummaryTeaser.tsx
@@ -20,7 +20,7 @@ export function BountySummaryTeaser(props: Props) {
     <SectionTeaserContainer onPress={props.onPress} title="Bounties">
       {loading ? (
         <LoadingBox />
-      ) : (
+      ) : data ? (
         <View style={styles.boxRow}>
           <Card mode="outlined" style={styles.card}>
             <View style={styles.itemRow}>
@@ -35,16 +35,16 @@ export function BountySummaryTeaser(props: Props) {
           </Card>
           <Padder scale={0.2} />
           <Card mode="outlined" style={styles.card}>
-            {data?.progressPercent && data.timeLeft && (
+            {data.timeLeft && (
               <ProgressChartWidget
                 title={`Funding period (${data.timeLeft[0]})`}
-                detail={`${data.progressPercent}%\n${data.timeLeft.join('\n')}`}
+                detail={`${data.progressPercent ?? 0}%\n${data.timeLeft.slice(0, 2).join('\n')}`}
                 data={[data.progressPercent / 100]}
               />
             )}
           </Card>
         </View>
-      )}
+      ) : null}
     </SectionTeaserContainer>
   );
 }

--- a/src/ui/components/ScrollView.tsx
+++ b/src/ui/components/ScrollView.tsx
@@ -1,0 +1,26 @@
+/* eslint-disable no-restricted-imports */
+import React from 'react';
+import {ScrollView as RNScrollView, RefreshControl} from 'react-native';
+import {RefetchQueries, useRefetch} from 'src/api/hooks/useRefetch';
+import {useTheme} from '@ui/library';
+
+type RNScrollViewProps = React.ComponentProps<typeof RNScrollView>;
+
+type Props = Omit<RNScrollViewProps, 'refreshControl'> & {
+  refetchQueries?: RefetchQueries;
+};
+
+export function ScrollView({children, refetchQueries, ...props}: Props) {
+  const {colors} = useTheme();
+  const {refreshing, refetch} = useRefetch(refetchQueries);
+
+  const refreshControl = refetchQueries ? (
+    <RefreshControl refreshing={refreshing} onRefresh={refetch} tintColor={colors.primary} colors={[colors.primary]} />
+  ) : undefined;
+
+  return (
+    <RNScrollView {...props} refreshControl={refreshControl}>
+      {children}
+    </RNScrollView>
+  );
+}

--- a/src/ui/components/ScrollViewRefetch.tsx
+++ b/src/ui/components/ScrollViewRefetch.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable no-restricted-imports */
 import React from 'react';
 import {ScrollView as RNScrollView, RefreshControl} from 'react-native';
 import {RefetchQueries, useRefetch} from 'src/api/hooks/useRefetch';
@@ -7,7 +6,7 @@ import {useTheme} from '@ui/library';
 type RNScrollViewProps = React.ComponentProps<typeof RNScrollView>;
 
 type Props = Omit<RNScrollViewProps, 'refreshControl'> & {
-  refetchQueries: RefetchQueries;
+  refetchQueries?: RefetchQueries;
 };
 
 export function ScrollViewRefetch({children, refetchQueries, ...props}: Props) {

--- a/src/ui/components/ScrollViewRefetch.tsx
+++ b/src/ui/components/ScrollViewRefetch.tsx
@@ -7,16 +7,16 @@ import {useTheme} from '@ui/library';
 type RNScrollViewProps = React.ComponentProps<typeof RNScrollView>;
 
 type Props = Omit<RNScrollViewProps, 'refreshControl'> & {
-  refetchQueries?: RefetchQueries;
+  refetchQueries: RefetchQueries;
 };
 
-export function ScrollView({children, refetchQueries, ...props}: Props) {
+export function ScrollViewRefetch({children, refetchQueries, ...props}: Props) {
   const {colors} = useTheme();
   const {refreshing, refetch} = useRefetch(refetchQueries);
 
-  const refreshControl = refetchQueries ? (
+  const refreshControl = (
     <RefreshControl refreshing={refreshing} onRefresh={refetch} tintColor={colors.primary} colors={[colors.primary]} />
-  ) : undefined;
+  );
 
   return (
     <RNScrollView {...props} refreshControl={refreshControl}>

--- a/src/ui/screens/DashboardScreen.tsx
+++ b/src/ui/screens/DashboardScreen.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import {StyleSheet} from 'react-native';
 import {DrawerNavigationProp} from '@react-navigation/drawer';
 import {CompositeNavigationProp} from '@react-navigation/native';
 import {StackNavigationProp} from '@react-navigation/stack';
@@ -6,12 +7,18 @@ import {BountySummaryTeaser} from '@ui/components/BountySummaryTeaser';
 import {CouncilSummaryTeaser} from '@ui/components/CouncilSummaryTeaser';
 import {DemocracySummaryTeaser} from '@ui/components/DemocracySummaryTeaser';
 import {TreasurySummaryTeaser} from '@ui/components/TreasurySummaryTeaser';
-import {ScrollView, StyleSheet} from 'react-native';
 import {DashboardStackParamList, DrawerParamList} from '@ui/navigation/navigation';
 import {bountiesScreen, councilScreen, democracyScreen, treasuryScreen} from '@ui/navigation/routeKeys';
 import {standardPadding} from '@ui/styles';
 import {Layout} from '@ui/components/Layout';
 import {Padder} from '@ui/components/Padder';
+import {ScrollView} from '@ui/components/ScrollView';
+import {DEMOCRACY_SUMMARY_QUERY} from 'src/api/hooks/useDemocracySummary';
+import {COUNCIL_SUMMARY_QUERY} from 'src/api/hooks/useCouncilSummary';
+import {BOUNTIES_SUMMARY_QUERY} from 'src/api/hooks/useBountiesSummary';
+
+// TODO: add treasury summary query when merged
+const refetchQueries = [DEMOCRACY_SUMMARY_QUERY, COUNCIL_SUMMARY_QUERY, BOUNTIES_SUMMARY_QUERY];
 
 type PropTypes = {
   navigation: CompositeNavigationProp<
@@ -23,7 +30,7 @@ type PropTypes = {
 function DashboardScreen({navigation}: PropTypes) {
   return (
     <Layout style={styles.container}>
-      <ScrollView contentContainerStyle={styles.scrollView}>
+      <ScrollView contentContainerStyle={styles.scrollView} refetchQueries={refetchQueries}>
         <DemocracySummaryTeaser onPress={() => navigation.navigate(democracyScreen)} />
         <Padder scale={1} />
         <CouncilSummaryTeaser onPress={() => navigation.navigate(councilScreen)} />

--- a/src/ui/screens/DashboardScreen.tsx
+++ b/src/ui/screens/DashboardScreen.tsx
@@ -12,7 +12,7 @@ import {bountiesScreen, councilScreen, democracyScreen, treasuryScreen} from '@u
 import {standardPadding} from '@ui/styles';
 import {Layout} from '@ui/components/Layout';
 import {Padder} from '@ui/components/Padder';
-import {ScrollView} from '@ui/components/ScrollView';
+import {ScrollViewRefetch} from '@ui/components/ScrollViewRefetch';
 import {DEMOCRACY_SUMMARY_QUERY} from 'src/api/hooks/useDemocracySummary';
 import {COUNCIL_SUMMARY_QUERY} from 'src/api/hooks/useCouncilSummary';
 import {BOUNTIES_SUMMARY_QUERY} from 'src/api/hooks/useBountiesSummary';
@@ -30,7 +30,7 @@ type PropTypes = {
 function DashboardScreen({navigation}: PropTypes) {
   return (
     <Layout style={styles.container}>
-      <ScrollView contentContainerStyle={styles.scrollView} refetchQueries={refetchQueries}>
+      <ScrollViewRefetch contentContainerStyle={styles.scrollView} refetchQueries={refetchQueries}>
         <DemocracySummaryTeaser onPress={() => navigation.navigate(democracyScreen)} />
         <Padder scale={1} />
         <CouncilSummaryTeaser onPress={() => navigation.navigate(councilScreen)} />
@@ -38,7 +38,7 @@ function DashboardScreen({navigation}: PropTypes) {
         <TreasurySummaryTeaser onPress={() => navigation.navigate(treasuryScreen)} />
         <Padder scale={1} />
         <BountySummaryTeaser onPress={() => navigation.navigate(bountiesScreen)} />
-      </ScrollView>
+      </ScrollViewRefetch>
     </Layout>
   );
 }


### PR DESCRIPTION
Introducing `ScrollViewRefetch` component which has the abstraction to refetch queries on pull to refresh. If no queries are passed with the `refetchQueries` prop it will refetch the active queries.