### PR TITLE
Fix add external account via QR Scanning

### DIFF
--- a/src/ui/screens/AddAccountScreen/AddAccountScreen.tsx
+++ b/src/ui/screens/AddAccountScreen/AddAccountScreen.tsx
@@ -64,6 +64,8 @@ export function AddAccountScreen({navigation}: {navigation: NavigationProp<AppSt
         if (isAddressValid(currentNetwork, parsed.address)) {
           dispatch({type: 'SET_ADDRESS', payload: parsed.address});
           dispatch({type: 'SET_STEP', payload: 'preview'});
+        } else {
+          Alert.alert('Validation Failed', 'Please scan the address from the correct network');
         }
       } catch (e) {
         Alert.alert('Validation Failed', 'Address is invalid.');

--- a/src/ui/screens/AddAccountScreen/AddAccountScreen.tsx
+++ b/src/ui/screens/AddAccountScreen/AddAccountScreen.tsx
@@ -1,4 +1,4 @@
-import React, {useCallback, useContext, useEffect, useMemo, useReducer, useRef} from 'react';
+import React, {useCallback, useContext, useEffect, useMemo, useReducer, useRef, useState} from 'react';
 import {Alert, StyleSheet, View} from 'react-native';
 import {NavigationProp} from '@react-navigation/native';
 import {Divider, Button, Tabs, TabScreen, TextInput} from '@ui/library';
@@ -59,10 +59,14 @@ export function AddAccountScreen({navigation}: {navigation: NavigationProp<AppSt
 
   const handleScan = useCallback(
     ({data}) => {
-      const parsed = parseAddress(data);
-      if (isAddressValid(currentNetwork, parsed.address)) {
-        dispatch({type: 'SET_ADDRESS', payload: parsed.address});
-        dispatch({type: 'SET_STEP', payload: 'preview'});
+      try {
+        const parsed = parseAddress(data);
+        if (isAddressValid(currentNetwork, parsed.address)) {
+          dispatch({type: 'SET_ADDRESS', payload: parsed.address});
+          dispatch({type: 'SET_STEP', payload: 'preview'});
+        }
+      } catch (e) {
+        Alert.alert('Validation Failed', 'Address is invalid.');
       }
     },
     [currentNetwork],
@@ -76,6 +80,8 @@ export function AddAccountScreen({navigation}: {navigation: NavigationProp<AppSt
 
     return disabled;
   }, [disabled, state, currentNetwork]);
+
+  const [tabIndex, setTabIndex] = useState(0);
 
   return (
     <Modalize
@@ -96,7 +102,7 @@ export function AddAccountScreen({navigation}: {navigation: NavigationProp<AppSt
               case 'input':
                 return (
                   <View style={styles.tabViewContainer}>
-                    <Tabs>
+                    <Tabs onChangeIndex={(index) => setTabIndex(index)}>
                       <TabScreen label="Type in" icon="keyboard">
                         <View style={globalStyles.paddedContainer}>
                           <TextInput
@@ -112,7 +118,7 @@ export function AddAccountScreen({navigation}: {navigation: NavigationProp<AppSt
                       </TabScreen>
                       <TabScreen label="Via QR" icon="qrcode">
                         <View style={globalStyles.paddedContainer}>
-                          <QRCamera onRead={handleScan} />
+                          {tabIndex === 1 && <QRCamera onRead={handleScan} />}
                         </View>
                       </TabScreen>
                     </Tabs>

--- a/src/ui/screens/AddAccountScreen/AddAccountScreen.tsx
+++ b/src/ui/screens/AddAccountScreen/AddAccountScreen.tsx
@@ -65,7 +65,7 @@ export function AddAccountScreen({navigation}: {navigation: NavigationProp<AppSt
           dispatch({type: 'SET_ADDRESS', payload: parsed.address});
           dispatch({type: 'SET_STEP', payload: 'preview'});
         } else {
-          Alert.alert('Validation Failed', 'Please scan the address from the correct network');
+          Alert.alert('Validation Failed', `The address must belong to the ${currentNetwork.name} network.`);
         }
       } catch (e) {
         Alert.alert('Validation Failed', 'Address is invalid.');


### PR DESCRIPTION
### Description

Actually if we scan a public address the feature is working fine. However, scanning a QR containing an invalid address such as wrong format or the QR for the private key from parity signer will result into an exception which was unhandled and eventually causing the crash.

In this PR the exception was handled with an alert message.

@stephanie-olp Can we also add a message to the user that they need to scan the QR for the public address. The QR scanning feature to add external account is mainly there so that the user doesn't have to input the address manually. So it will have to be the public address always.
