### PR TITLE
Fix Polkassembly webview

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -816,7 +816,7 @@ SPEC CHECKSUMS:
   boost: a7c83b31436843459a1961bfd74b96033dc77234
   BVLinearGradient: e3aad03778a456d77928f594a649e96995f1c872
   CocoaAsyncSocket: 065fd1e645c7abab64f7a6a2007a48038fdc6a99
-  DoubleConversion: 831926d9b8bf8166fd87886c4abab286c2422662
+  DoubleConversion: cf9b38bf0b2d048436d9a82ad2abe1404f11e7de
   FBLazyVector: 808f741ddb0896a20e5b98cc665f5b3413b072e2
   FBReactNativeSpec: 94473205b8741b61402e8c51716dea34aa3f5b2f
   Firebase: 7e8fe528c161b9271d365217a74c16aaf834578e
@@ -837,7 +837,7 @@ SPEC CHECKSUMS:
   Flipper-RSocket: d9d9ade67cbecf6ac10730304bf5607266dd2541
   FlipperKit: de934d365bfc0af358d3b7b7d453c24ffddd7cac
   fmt: ff9d55029c625d3757ed641535fd4a75fedc7ce9
-  glog: 5337263514dd6f09803962437687240c5dc39aa4
+  glog: 73c2498ac6884b13ede40eda8228cb1eee9d9d62
   GoogleDataTransport: 629c20a4d363167143f30ea78320d5a7eb8bd940
   GoogleUtilities: e0913149f6b0625b553d70dae12b49fc62914fd1
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913

--- a/src/ui/components/CouncilSummaryTeaser.tsx
+++ b/src/ui/components/CouncilSummaryTeaser.tsx
@@ -34,13 +34,15 @@ export function CouncilSummaryTeaser(props: PropTypes) {
             </Card>
             <Padder scale={0.2} />
             <Card mode="outlined" style={styles.card}>
-              <ProgressChartWidget
-                title={`Term Progress (${council?.termProgress.termDurationParts[0]})`}
-                detail={`${council?.termProgress.percentage}%\n${council?.termProgress.termLeftParts?.[0] || ''}${
-                  council?.termProgress.termLeftParts?.[1] ? `\n${council?.termProgress.termLeftParts[1]}` : ''
-                }`}
-                data={[council?.termProgress.percentage ?? 0 / 100]}
-              />
+              {council ? (
+                <ProgressChartWidget
+                  title={`Term Progress (${council.termProgress.termDurationParts[0]})`}
+                  detail={`${council.termProgress.percentage}%\n${council.termProgress.termLeftParts
+                    ?.slice(0, 2)
+                    .join('\n')}`}
+                  data={[council.termProgress.percentage / 100]}
+                />
+              ) : null}
             </Card>
           </View>
           <Padder scale={0.2} />

--- a/src/ui/screens/MotionDetailScreen.tsx
+++ b/src/ui/screens/MotionDetailScreen.tsx
@@ -176,6 +176,7 @@ export function MotionDetailScreen({route, navigation}: PropTypes) {
             injectedJavaScript={`(function() {
                 // remove some html element
                 document.getElementById('menubar').remove();
+                document.getElementsByClassName('sidebar-parent')[0].parentElement.remove();
                 var footer = document.getElementsByTagName('footer');
                 Array.prototype.forEach.call(footer, el => el.remove());
             })();`}


### PR DESCRIPTION
### Description

Remove the sidebar of the polkassembly site when we load it into our webview in the motion detail page.

Since the polkassembly site is not fully responsive the sidebar blocks the content in the web page and we can not do anything about it when loaded in external browser. For example in treasury and democracy.

Also fixed an issue with progress chart in the council summary teaser.
