### PR TITLE
Custom wait function to wait for async hooks while testing components

### DIFF
--- a/src/testUtils.tsx
+++ b/src/testUtils.tsx
@@ -4,6 +4,7 @@ import {render, RenderOptions} from '@testing-library/react-native';
 import {ApolloProvider, ApolloClient, InMemoryCache, HttpLink} from '@apollo/client';
 import fetch from 'cross-fetch';
 import ThemeProvider from 'context/ThemeContext';
+import {act} from '@testing-library/react-native';
 
 export const client = new ApolloClient({
   cache: new InMemoryCache(),
@@ -36,3 +37,7 @@ jest.mock('@react-navigation/native', () => {
 
 export * from '@testing-library/react-native';
 export {customRender as render};
+
+export function wait(timeOut = 500) {
+  return act(() => new Promise((resolve) => setTimeout(resolve, timeOut)));
+}

--- a/src/ui/components/DemocracySummaryTeaser.test.tsx
+++ b/src/ui/components/DemocracySummaryTeaser.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {render, waitFor} from 'src/testUtils';
+import {render, wait} from 'src/testUtils';
 import {DemocracySummaryTeaser} from './DemocracySummaryTeaser';
 
 const onPressEvent = jest.fn();
@@ -11,7 +11,9 @@ describe('DemocracySummaryTeaser component', () => {
   });
 
   it('should render the component with the data', async () => {
-    const {getAllByText} = await waitFor(() => render(<DemocracySummaryTeaser onPress={onPressEvent} />));
+    const {getAllByText} = render(<DemocracySummaryTeaser onPress={onPressEvent} />);
+    await wait();
+
     const democracyElement = getAllByText('Democracy');
     expect(democracyElement).toHaveLength(1);
     const totalElements = getAllByText('Total');

--- a/src/ui/components/RegistrarList.test.tsx
+++ b/src/ui/components/RegistrarList.test.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 import React from 'react';
-import {render, waitFor, within} from 'src/testUtils';
+import {render, wait, within} from 'src/testUtils';
 import RegistrarList from '@ui/components/RegistrarList';
 
 describe('RegistrarList component', () => {
@@ -10,7 +10,8 @@ describe('RegistrarList component', () => {
   });
 
   it('renders data correctly', async () => {
-    const {getByTestId, getAllByTestId} = await waitFor(() => render(<RegistrarList />));
+    const {getByTestId, getAllByTestId} = render(<RegistrarList />);
+    await wait();
 
     const countContainer = getByTestId('registrars_count');
     expect(within(countContainer).getByText('Count')).toBeTruthy();


### PR DESCRIPTION
### Description

Instead of using `waitFor` to render components having an async hook created custom `wait` function wrapped with `act`.

`waitFor` leaves some sort of open async handle that results into warnings like following.

`Jest has detected the following 1 open handle potentially keeping Jest from exiting:`
`A worker process has failed to exit gracefully and has been force exited. This is likely caused by tests leaking due to improper teardown.`

The custom `wait` function enables us to wait for the async operation to be finished in the component.
